### PR TITLE
ci: Switch from --nocapture to --no-capture

### DIFF
--- a/.github/workflows/aws_v4.yml
+++ b/.github/workflows/aws_v4.yml
@@ -91,7 +91,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Running signing tests"
-          cargo test signing:: --no-fail-fast -- --nocapture
+          cargo test signing:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # EnvCredentialProvider test
@@ -118,7 +118,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing EnvCredentialProvider"
-          cargo test test_env_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_env_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # ProfileCredentialProvider test
@@ -166,7 +166,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing ProfileCredentialProvider"
-          cargo test test_profile_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_profile_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # AssumeRoleCredentialProvider test
@@ -195,7 +195,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing AssumeRoleCredentialProvider"
-          cargo test test_assume_role_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_assume_role_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # AssumeRoleWithWebIdentityCredentialProvider test
@@ -238,7 +238,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing AssumeRoleWithWebIdentityCredentialProvider"
-          cargo test test_assume_role_with_web_identity_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_assume_role_with_web_identity_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/web_identity_token
@@ -306,7 +306,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing IMDSv2CredentialProvider"
-          cargo test test_imds_v2_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_imds_v2_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           RUST_LOG: DEBUG
@@ -342,7 +342,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing ECSCredentialProvider with relative URI"
-          cargo test test_ecs_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_ecs_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           RUST_LOG: DEBUG
@@ -354,7 +354,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing ECSCredentialProvider with full URI"
-          cargo test test_ecs_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_ecs_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           RUST_LOG: DEBUG
@@ -428,7 +428,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing SSOCredentialProvider"
-          cargo test test_sso_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_sso_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           RUST_LOG: DEBUG
@@ -482,7 +482,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing ProcessCredentialProvider (default profile)"
-          cargo test test_process_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_process_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           RUST_LOG: DEBUG
@@ -493,7 +493,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing ProcessCredentialProvider (named profile)"
-          cargo test test_process_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_process_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           RUST_LOG: DEBUG
@@ -534,7 +534,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing CognitoIdentityCredentialProvider (Unauthenticated)"
-          cargo test test_cognito_identity_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_cognito_identity_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
         env:
           REQSIGN_AWS_V4_TEST_COGNITO: on
@@ -575,7 +575,7 @@ jobs:
         working-directory: ./services/aws-v4
         run: |
           echo "::group::Testing S3ExpressSessionProvider"
-          cargo test test_s3_express --no-fail-fast -- --nocapture
+          cargo test test_s3_express --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # Summary report

--- a/.github/workflows/azure_storage.yml
+++ b/.github/workflows/azure_storage.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./services/azure-storage
         run: |
           echo "::group::Running signing tests"
-          cargo test signing:: --no-fail-fast -- --nocapture
+          cargo test signing:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # EnvCredentialProvider test
@@ -118,7 +118,7 @@ jobs:
         working-directory: ./services/azure-storage
         run: |
           echo "::group::Testing EnvCredentialProvider"
-          cargo test credential_providers::env:: --no-fail-fast -- --nocapture
+          cargo test credential_providers::env:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # StaticCredentialProvider test
@@ -147,7 +147,7 @@ jobs:
         working-directory: ./services/azure-storage
         run: |
           echo "::group::Testing StaticCredentialProvider"
-          cargo test credential_providers::static_provider:: --no-fail-fast -- --nocapture
+          cargo test credential_providers::static_provider:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # ClientSecretCredentialProvider test
@@ -175,7 +175,7 @@ jobs:
         working-directory: ./services/azure-storage
         run: |
           echo "::group::Testing ClientSecretCredentialProvider"
-          cargo test credential_providers::client_secret:: --no-fail-fast -- --nocapture
+          cargo test credential_providers::client_secret:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # ClientCertificateCredentialProvider test
@@ -216,7 +216,7 @@ jobs:
           REQSIGN_AZURE_STORAGE_TEST_CLIENT_CERTIFICATE: on
         run: |
           echo "::group::Testing ClientCertificateCredentialProvider"
-          cargo test credential_providers::client_certificate:: --no-fail-fast -- --nocapture
+          cargo test credential_providers::client_certificate:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # Azure CLI test (only on runners with Azure CLI)
@@ -254,7 +254,7 @@ jobs:
           REQSIGN_AZURE_STORAGE_TEST_CLI: on
         run: |
           echo "::group::Testing AzureCliCredentialProvider"
-          cargo test credential_providers::azure_cli:: --no-fail-fast -- --nocapture
+          cargo test credential_providers::azure_cli:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # IMDS test with mock server
@@ -278,7 +278,7 @@ jobs:
           AZURE_IMDS_ENDPOINT: http://localhost:8080/metadata/identity/oauth2/token
         run: |
           echo "::group::Testing ImdsCredentialProvider"
-          cargo test credential_providers::imds:: --no-fail-fast -- --nocapture
+          cargo test credential_providers::imds:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
       - name: Stop mock server
         if: always()

--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: ./services/google
         run: |
           echo "::group::Running signing tests"
-          cargo test signing:: --no-fail-fast -- --nocapture
+          cargo test signing:: --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # DefaultCredentialProvider test
@@ -118,7 +118,7 @@ jobs:
         working-directory: ./services/google
         run: |
           echo "::group::Testing DefaultCredentialProvider"
-          cargo test test_default_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_default_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # StaticCredentialProvider test
@@ -145,7 +145,7 @@ jobs:
         working-directory: ./services/google
         run: |
           echo "::group::Testing StaticCredentialProvider"
-          cargo test test_static_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_static_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # AuthorizedUserCredentialProvider test
@@ -174,7 +174,7 @@ jobs:
         working-directory: ./services/google
         run: |
           echo "::group::Testing AuthorizedUserCredentialProvider"
-          cargo test test_authorized_user_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_authorized_user_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # ExternalAccountCredentialProvider test (Workload Identity)
@@ -212,7 +212,7 @@ jobs:
           echo "::group::Testing ExternalAccountCredentialProvider"
           # The google-github-actions/auth action sets GOOGLE_APPLICATION_CREDENTIALS
           # reqsign should be able to use this external_account configuration
-          cargo test test_external_account_with_workload_identity --no-fail-fast -- --nocapture
+          cargo test test_external_account_with_workload_identity --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # ImpersonatedServiceAccountCredentialProvider test
@@ -241,7 +241,7 @@ jobs:
         working-directory: ./services/google
         run: |
           echo "::group::Testing ImpersonatedServiceAccountCredentialProvider"
-          cargo test test_impersonated_service_account_credential_provider --no-fail-fast -- --nocapture
+          cargo test test_impersonated_service_account_credential_provider --no-fail-fast -- --no-capture
           echo "::endgroup::"
 
   # VmMetadataCredentialProvider test
@@ -264,7 +264,7 @@ jobs:
           echo "::group::Testing VmMetadataCredentialProvider with mock"
           export REQSIGN_GOOGLE_TEST_VM_METADATA_MOCK=on
           export GCE_METADATA_HOST=127.0.0.1:8080
-          cargo test test_vm_metadata_credential_provider_with_mock --no-fail-fast -- --nocapture
+          cargo test test_vm_metadata_credential_provider_with_mock --no-fail-fast -- --no-capture
           echo "::endgroup::"
       - name: Stop mock server
         if: always()


### PR DESCRIPTION
`--no-capture` was added in 1.88, with `--nocapture` being soft-deprecated.
https://releases.rs/docs/1.88.0/#libraries