### PR TITLE
ci: use `cargo publish --workspace` for publishing all crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,47 +46,12 @@ jobs:
             echo "This is a release version, proceeding with publish"
           fi
 
-  # Phase 1: Publish core
-  publish-core:
-    name: Publish reqsign-core
+  # Publish Workspace
+  publish:
+    name: Publish Workspace
     runs-on: ubuntu-latest
     needs: check-version
     if: needs.check-version.outputs.is_prerelease == 'false'
     steps:
       - uses: actions/checkout@v5
-      - run: cargo publish -p reqsign-core
-
-
-  # Phase 2: Publish context and service crates (depend on core)
-  publish-dependencies:
-    name: Publish ${{ matrix.package }}
-    runs-on: ubuntu-latest
-    needs: [check-version, publish-core]
-    if: needs.check-version.outputs.is_prerelease == 'false'
-    strategy:
-      matrix:
-        package:
-          - reqsign-command-execute-tokio
-          - reqsign-http-send-reqwest
-          - reqsign-file-read-tokio
-          - reqsign-aliyun-oss
-          - reqsign-aws-v4
-          - reqsign-azure-storage
-          - reqsign-google
-          - reqsign-huaweicloud-obs
-          - reqsign-oracle
-          - reqsign-tencent-cos
-    steps:
-      - uses: actions/checkout@v5
-      - run: cargo publish -p ${{ matrix.package }}
-
-
-  # Phase 3: Publish main crate (depends on all others)
-  publish-reqsign:
-    name: Publish reqsign
-    runs-on: ubuntu-latest
-    needs: [check-version, publish-dependencies]
-    if: needs.check-version.outputs.is_prerelease == 'false'
-    steps:
-      - uses: actions/checkout@v5
-      - run: cargo publish -p reqsign
+      - run: cargo publish --workspace


### PR DESCRIPTION
- Replace individual `cargo publish -p <crate>` steps with a single `cargo publish --workspace`
- Requires Rust 1.90.0 or newer

References:
- [Rust 1.90.0 release notes: Cargo adds native support for workspace publishing](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#cargo-adds-native-support-for-workspace-publishing)