### PR TITLE
chore: bump major version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-reqsign-aliyun-oss = { version = "1.1.0", path = "services/aliyun-oss" }
-reqsign-aws-v4 = { version = "1.1.0", path = "services/aws-v4" }
-reqsign-azure-storage = { version = "1.1.0", path = "services/azure-storage" }
-reqsign-command-execute-tokio = { version = "1.1.0", path = "context/command-execute-tokio" }
-reqsign-core = { version = "1.1.0", path = "core" }
-reqsign-file-read-tokio = { version = "1.1.0", path = "context/file-read-tokio" }
-reqsign-google = { version = "1.1.0", path = "services/google" }
-reqsign-http-send-reqwest = { version = "1.1.0", path = "context/http-send-reqwest" }
-reqsign-huaweicloud-obs = { version = "1.1.0", path = "services/huaweicloud-obs" }
-reqsign-oracle = { version = "1.1.0", path = "services/oracle" }
-reqsign-tencent-cos = { version = "1.1.0", path = "services/tencent-cos" }
+reqsign-aliyun-oss = { version = "2.0.0", path = "services/aliyun-oss" }
+reqsign-aws-v4 = { version = "2.0.0", path = "services/aws-v4" }
+reqsign-azure-storage = { version = "2.0.0", path = "services/azure-storage" }
+reqsign-command-execute-tokio = { version = "2.0.0", path = "context/command-execute-tokio" }
+reqsign-core = { version = "2.0.0", path = "core" }
+reqsign-file-read-tokio = { version = "2.0.0", path = "context/file-read-tokio" }
+reqsign-google = { version = "2.0.0", path = "services/google" }
+reqsign-http-send-reqwest = { version = "2.0.0", path = "context/http-send-reqwest" }
+reqsign-huaweicloud-obs = { version = "2.0.0", path = "services/huaweicloud-obs" }
+reqsign-oracle = { version = "2.0.0", path = "services/oracle" }
+reqsign-tencent-cos = { version = "2.0.0", path = "services/tencent-cos" }
 
 # Crates.io dependencies
 anyhow = "1"

--- a/context/command-execute-tokio/Cargo.toml
+++ b/context/command-execute-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-command-execute-tokio"
-version = "1.1.0"
+version = "2.0.0"
 
 categories = ["asynchronous"]
 description = "Tokio-based command execution implementation for reqsign"

--- a/context/file-read-tokio/Cargo.toml
+++ b/context/file-read-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-file-read-tokio"
-version = "1.1.0"
+version = "2.0.0"
 
 categories = ["asynchronous"]
 description = "Tokio-based file reader implementation for reqsign"

--- a/context/http-send-reqwest/Cargo.toml
+++ b/context/http-send-reqwest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-http-send-reqwest"
-version = "1.1.0"
+version = "2.0.0"
 
 categories = ["asynchronous"]
 description = "Reqwest-based HTTP client implementation for reqsign."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-core"
-version = "1.1.0"
+version = "2.0.0"
 
 categories = ["command-line-utilities", "web-programming"]
 description = "Signing API requests without effort."

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -30,6 +30,16 @@ pub struct Timestamp(jiff::Timestamp);
 impl FromStr for Timestamp {
     type Err = Error;
 
+    /// Parse a timestamp by the default [`DateTimeParser`].
+    ///
+    /// All of them are valid time:
+    ///
+    /// - `2022-03-13T07:20:04Z`
+    /// - `2022-03-01T08:12:34+00:00`
+    /// - `2022-03-01T08:12:34.00+00:00`
+    /// - `2022-07-08T02:14:07+02:00[Europe/Paris]`
+    ///
+    /// [`DateTimeParser`]: jiff::fmt::temporal::DateTimeParser
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.parse() {
             Ok(t) => Ok(Timestamp(t)),
@@ -130,25 +140,6 @@ impl Timestamp {
                 "convert '{second}' seconds into timestamp failed"
             ))
             .with_source(err)),
-        }
-    }
-
-    /// Parse a timestamp by the default [`DateTimeParser`].
-    ///
-    /// All of them are valid time:
-    ///
-    /// - `2022-03-13T07:20:04Z`
-    /// - `2022-03-01T08:12:34+00:00`
-    /// - `2022-03-01T08:12:34.00+00:00`
-    /// - `2024-06-15T07-04[America/New_York]`
-    ///
-    /// [`DateTimeParser`]: jiff::fmt::temporal::DateTimeParser
-    pub fn parse_timestamp(s: &str) -> crate::Result<Timestamp> {
-        match s.parse() {
-            Ok(t) => Ok(Timestamp(t)),
-            Err(err) => Err(
-                Error::unexpected(format!("parse '{s}' into timestamp failed")).with_source(err),
-            ),
         }
     }
 
@@ -260,10 +251,7 @@ mod tests {
             "2022-03-01T08:12:34+00:00",
             "2022-03-01T08:12:34.00+00:00",
         ] {
-            assert_eq!(
-                t,
-                Timestamp::parse_timestamp(v).expect("must be valid time")
-            );
+            assert_eq!(t, v.parse().expect("must be valid time"));
         }
     }
 }

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -18,66 +18,127 @@
 //! Time related utils.
 
 use crate::Error;
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::time::Duration;
 
-/// DateTime is the alias for `jiff::Timestamp`.
-pub type Timestamp = jiff::Timestamp;
+/// An instant in time represented as the number of nanoseconds since the Unix epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Timestamp(jiff::Timestamp);
 
-/// Create datetime of now.
-pub fn now() -> Timestamp {
-    Timestamp::now()
+impl Timestamp {
+    /// Create the timestamp of now.
+    pub fn now() -> Self {
+        Self(jiff::Timestamp::now())
+    }
+
+    /// Format the timestamp into date: `20220301`
+    pub fn format_date(self) -> String {
+        self.0.strftime("%Y%m%d").to_string()
+    }
+
+    /// Format the timestamp into ISO8601: `20220313T072004Z`
+    pub fn format_iso8601(self) -> String {
+        self.0.strftime("%Y%m%dT%H%M%SZ").to_string()
+    }
+
+    /// Format the timestamp into http date: `Sun, 06 Nov 1994 08:49:37 GMT`
+    ///
+    /// ## Note
+    ///
+    /// HTTP date is slightly different from RFC2822.
+    ///
+    /// - Timezone is fixed to GMT.
+    /// - Day must be 2 digit.
+    pub fn format_http_date(self) -> String {
+        self.0.strftime("%a, %d %b %Y %T GMT").to_string()
+    }
+
+    /// Format the timestamp into RFC3339: `2022-03-13T07:20:04Z`
+    pub fn format_rfc3339(self) -> String {
+        self.0.strftime("%FT%TZ").to_string()
+    }
+
+    /// Parse a timestamp from RFC3339.
+    ///
+    /// All of them are valid time:
+    ///
+    /// - `2022-03-13T07:20:04Z`
+    /// - `2022-03-01T08:12:34+00:00`
+    /// - `2022-03-01T08:12:34.00+00:00`
+    pub fn parse_rfc3339(s: &str) -> crate::Result<Timestamp> {
+        match s.parse() {
+            Ok(t) => Ok(Timestamp(t)),
+            Err(err) => {
+                Err(Error::unexpected(format!("parse '{s}' into rfc3339 failed")).with_source(err))
+            }
+        }
+    }
+
+    /// Parse a timestamp from RFC2822.
+    ///
+    /// All of them are valid time:
+    ///
+    /// - `Sat, 13 Jul 2024 15:09:59 -0400`
+    /// - `Mon, 15 Aug 2022 16:50:12 GMT`
+    pub fn parse_rfc2822(s: &str) -> crate::Result<Timestamp> {
+        match jiff::fmt::rfc2822::parse(s) {
+            Ok(zoned) => Ok(Timestamp(zoned.timestamp())),
+            Err(err) => {
+                Err(Error::unexpected(format!("parse '{s}' into rfc2822 failed")).with_source(err))
+            }
+        }
+    }
+
+    /// Parse the string format "2023-10-31 21:59:10.000000".
+    pub fn parse_datetime_utc(s: &str) -> crate::Result<Timestamp> {
+        let dt = s.parse::<jiff::civil::DateTime>().map_err(|err| {
+            Error::unexpected(format!("parse '{s}' into datetime failed")).with_source(err)
+        })?;
+
+        let ts = jiff::tz::TimeZone::UTC.to_timestamp(dt).map_err(|err| {
+            Error::unexpected(format!("convert '{s}' into timestamp failed")).with_source(err)
+        })?;
+
+        Ok(Timestamp(ts))
+    }
 }
 
-/// Format time into date: `20220301`
-pub fn format_date(t: Timestamp) -> String {
-    t.strftime("%Y%m%d").to_string()
+impl Add<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    fn add(self, rhs: Duration) -> Timestamp {
+        let ts = self
+            .0
+            .checked_add(rhs)
+            .expect("adding unsigned duration to timestamp overflowed");
+
+        Timestamp(ts)
+    }
 }
 
-/// Format time into ISO8601: `20220313T072004Z`
-pub fn format_iso8601(t: Timestamp) -> String {
-    t.strftime("%Y%m%dT%H%M%SZ").to_string()
+impl AddAssign<Duration> for Timestamp {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = *self + rhs
+    }
 }
 
-/// Format time into http date: `Sun, 06 Nov 1994 08:49:37 GMT`
-///
-/// ## Note
-///
-/// HTTP date is slightly different from RFC2822.
-///
-/// - Timezone is fixed to GMT.
-/// - Day must be 2 digit.
-pub fn format_http_date(t: Timestamp) -> String {
-    t.strftime("%a, %d %b %Y %T GMT").to_string()
+impl Sub<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    fn sub(self, rhs: Duration) -> Timestamp {
+        let ts = self
+            .0
+            .checked_sub(rhs)
+            .expect("subtracting unsigned duration from timestamp overflowed");
+
+        Timestamp(ts)
+    }
 }
 
-/// Format time into RFC3339: `2022-03-13T07:20:04Z`
-pub fn format_rfc3339(t: Timestamp) -> String {
-    t.strftime("%FT%TZ").to_string()
-}
-
-/// Parse time from RFC3339.
-///
-/// All of them are valid time:
-///
-/// - `2022-03-13T07:20:04Z`
-/// - `2022-03-01T08:12:34+00:00`
-/// - `2022-03-01T08:12:34.00+00:00`
-pub fn parse_rfc3339(s: &str) -> crate::Result<Timestamp> {
-    s.parse().map_err(|err| {
-        Error::unexpected(format!("parse '{s}' into rfc3339 failed")).with_source(err)
-    })
-}
-
-/// Parse time from RFC2822.
-///
-/// All of them are valid time:
-///
-/// - `Sat, 13 Jul 2024 15:09:59 -0400`
-/// - `Mon, 15 Aug 2022 16:50:12 GMT`
-pub fn parse_rfc2822(s: &str) -> crate::Result<Timestamp> {
-    let zoned = jiff::fmt::rfc2822::parse(s).map_err(|err| {
-        Error::unexpected(format!("parse '{s}' into rfc2822 failed")).with_source(err)
-    })?;
-    Ok(zoned.timestamp())
+impl SubAssign<Duration> for Timestamp {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = *self - rhs
+    }
 }
 
 #[cfg(test)]
@@ -85,31 +146,31 @@ mod tests {
     use super::*;
 
     fn test_time() -> Timestamp {
-        "2022-03-01T08:12:34Z".parse().unwrap()
+        Timestamp("2022-03-01T08:12:34Z".parse().unwrap())
     }
 
     #[test]
     fn test_format_date() {
         let t = test_time();
-        assert_eq!("20220301", format_date(t))
+        assert_eq!("20220301", t.format_date())
     }
 
     #[test]
     fn test_format_ios8601() {
         let t = test_time();
-        assert_eq!("20220301T081234Z", format_iso8601(t))
+        assert_eq!("20220301T081234Z", t.format_iso8601())
     }
 
     #[test]
     fn test_format_http_date() {
         let t = test_time();
-        assert_eq!("Tue, 01 Mar 2022 08:12:34 GMT", format_http_date(t))
+        assert_eq!("Tue, 01 Mar 2022 08:12:34 GMT", t.format_http_date())
     }
 
     #[test]
     fn test_format_rfc3339() {
         let t = test_time();
-        assert_eq!("2022-03-01T08:12:34Z", format_rfc3339(t))
+        assert_eq!("2022-03-01T08:12:34Z", t.format_rfc3339())
     }
 
     #[test]
@@ -121,7 +182,7 @@ mod tests {
             "2022-03-01T08:12:34+00:00",
             "2022-03-01T08:12:34.00+00:00",
         ] {
-            assert_eq!(t, parse_rfc3339(v).expect("must be valid time"));
+            assert_eq!(t, Timestamp::parse_rfc3339(v).expect("must be valid time"));
         }
     }
 }

--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign"
-version = "0.17.1"
+version = "0.18.0"
 
 categories = ["authentication", "web-programming::http-client"]
 description = "Signing HTTP requests for AWS, Azure, Google, Huawei, Aliyun, Tencent and Oracle services"

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aliyun-oss"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "Aliyun OSS signing implementation for reqsign."
 

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -30,7 +30,6 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 log = { workspace = true }
 percent-encoding = { workspace = true }
 reqsign-core = { workspace = true }

--- a/services/aliyun-oss/src/credential.rs
+++ b/services/aliyun-oss/src/credential.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use reqsign_core::SigningCredential;
-use reqsign_core::time::{Timestamp, now};
+use reqsign_core::time::Timestamp;
 use reqsign_core::utils::Redact;
 use std::fmt::{Debug, Formatter};
+use std::time::Duration;
 
 /// Credential that holds the access_key and secret_key.
 #[derive(Default, Clone)]
@@ -54,7 +55,7 @@ impl SigningCredential for Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + jiff::SignedDuration::from_mins(2))
+            .map(|v| v > Timestamp::now() + Duration::from_secs(120))
         {
             return valid;
         }

--- a/services/aliyun-oss/src/provide_credential/assume_role_with_oidc.rs
+++ b/services/aliyun-oss/src/provide_credential/assume_role_with_oidc.rs
@@ -119,7 +119,7 @@ impl ProvideCredential for AssumeRoleWithOidcCredentialProvider {
             access_key_id: resp_cred.access_key_id,
             access_key_secret: resp_cred.access_key_secret,
             security_token: Some(resp_cred.security_token),
-            expires_in: Some(Timestamp::parse_timestamp(&resp_cred.expiration)?),
+            expires_in: Some(resp_cred.expiration.parse()?),
         };
 
         Ok(Some(cred))

--- a/services/aliyun-oss/src/provide_credential/assume_role_with_oidc.rs
+++ b/services/aliyun-oss/src/provide_credential/assume_role_with_oidc.rs
@@ -18,7 +18,7 @@
 use crate::{Credential, constants::*};
 use async_trait::async_trait;
 use reqsign_core::Result;
-use reqsign_core::time::{format_rfc3339, now, parse_rfc3339};
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential};
 use serde::Deserialize;
 
@@ -87,7 +87,7 @@ impl ProvideCredential for AssumeRoleWithOidcCredentialProvider {
             provider_arn,
             role_arn,
             role_session_name,
-            format_rfc3339(now()),
+            Timestamp::now().format_rfc3339_zulu(),
             token
         );
 
@@ -119,7 +119,7 @@ impl ProvideCredential for AssumeRoleWithOidcCredentialProvider {
             access_key_id: resp_cred.access_key_id,
             access_key_secret: resp_cred.access_key_secret,
             security_token: Some(resp_cred.security_token),
-            expires_in: Some(parse_rfc3339(&resp_cred.expiration)?),
+            expires_in: Some(Timestamp::parse_timestamp(&resp_cred.expiration)?),
         };
 
         Ok(Some(cred))

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -36,7 +36,6 @@ async-trait = { workspace = true }
 bytes = "1.7.2"
 form_urlencoded = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 log = { workspace = true }
 percent-encoding = { workspace = true }
 quick-xml = { workspace = true }

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aws-v4"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "AWS SigV4 signing implementation for reqsign."
 

--- a/services/aws-v4/src/credential.rs
+++ b/services/aws-v4/src/credential.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use reqsign_core::SigningCredential;
-use reqsign_core::time::{Timestamp, now};
+use reqsign_core::time::Timestamp;
 use reqsign_core::utils::Redact;
 use std::fmt::{Debug, Formatter};
+use std::time::Duration;
 
 /// Credential that holds the access_key and secret_key.
 #[derive(Default, Clone)]
@@ -54,7 +55,7 @@ impl SigningCredential for Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + jiff::SignedDuration::from_mins(2))
+            .map(|v| v > Timestamp::now() + Duration::from_secs(120))
         {
             return valid;
         }

--- a/services/aws-v4/src/provide_credential/assume_role.rs
+++ b/services/aws-v4/src/provide_credential/assume_role.rs
@@ -22,7 +22,6 @@ use crate::provide_credential::utils::{parse_sts_error, sts_endpoint};
 use async_trait::async_trait;
 use bytes::Bytes;
 use quick_xml::de;
-use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result, Signer};
 use serde::Deserialize;
 use std::fmt::Write;
@@ -238,14 +237,12 @@ impl ProvideCredential for AssumeRoleCredentialProvider {
             access_key_id: resp_cred.access_key_id,
             secret_access_key: resp_cred.secret_access_key,
             session_token: Some(resp_cred.session_token),
-            expires_in: Some(
-                Timestamp::parse_timestamp(&resp_cred.expiration).map_err(|e| {
-                    Error::unexpected("failed to parse AssumeRole credential expiration")
-                        .with_source(e)
-                        .with_context(format!("expiration_value: {}", resp_cred.expiration))
-                        .with_context(format!("role_arn: {}", self.role_arn))
-                })?,
-            ),
+            expires_in: Some(resp_cred.expiration.parse().map_err(|e| {
+                Error::unexpected("failed to parse AssumeRole credential expiration")
+                    .with_source(e)
+                    .with_context(format!("expiration_value: {}", resp_cred.expiration))
+                    .with_context(format!("role_arn: {}", self.role_arn))
+            })?),
         };
 
         Ok(Some(cred))

--- a/services/aws-v4/src/provide_credential/assume_role_with_web_identity.rs
+++ b/services/aws-v4/src/provide_credential/assume_role_with_web_identity.rs
@@ -20,7 +20,7 @@ use crate::provide_credential::utils::{parse_sts_error, sts_endpoint};
 use async_trait::async_trait;
 use bytes::Bytes;
 use quick_xml::de;
-use reqsign_core::time::parse_rfc3339;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result, utils::Redact};
 use serde::Deserialize;
 use std::fmt::{Debug, Formatter};
@@ -211,12 +211,14 @@ impl ProvideCredential for AssumeRoleWithWebIdentityCredentialProvider {
             access_key_id: resp_cred.access_key_id,
             secret_access_key: resp_cred.secret_access_key,
             session_token: Some(resp_cred.session_token),
-            expires_in: Some(parse_rfc3339(&resp_cred.expiration).map_err(|e| {
-                Error::unexpected("failed to parse web identity credential expiration")
-                    .with_source(e)
-                    .with_context(format!("expiration_value: {}", resp_cred.expiration))
-                    .with_context(format!("role_arn: {role_arn}"))
-            })?),
+            expires_in: Some(
+                Timestamp::parse_timestamp(&resp_cred.expiration).map_err(|e| {
+                    Error::unexpected("failed to parse web identity credential expiration")
+                        .with_source(e)
+                        .with_context(format!("expiration_value: {}", resp_cred.expiration))
+                        .with_context(format!("role_arn: {role_arn}"))
+                })?,
+            ),
         };
 
         Ok(Some(cred))

--- a/services/aws-v4/src/provide_credential/ecs.rs
+++ b/services/aws-v4/src/provide_credential/ecs.rs
@@ -19,7 +19,6 @@ use crate::Credential;
 use async_trait::async_trait;
 use http::{HeaderValue, Method, Request, StatusCode};
 use log::debug;
-use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result};
 use serde::Deserialize;
 
@@ -295,7 +294,7 @@ impl ProvideCredential for ECSCredentialProvider {
                 .with_context(format!("endpoint: {endpoint}"))
         })?;
 
-        let expires_in = Timestamp::parse_timestamp(&creds.expiration).map_err(|e| {
+        let expires_in = creds.expiration.parse().map_err(|e| {
             Error::unexpected("failed to parse ECS credential expiration")
                 .with_source(e)
                 .with_context(format!("expiration_value: {}", creds.expiration))

--- a/services/aws-v4/src/provide_credential/ecs.rs
+++ b/services/aws-v4/src/provide_credential/ecs.rs
@@ -19,6 +19,7 @@ use crate::Credential;
 use async_trait::async_trait;
 use http::{HeaderValue, Method, Request, StatusCode};
 use log::debug;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result};
 use serde::Deserialize;
 
@@ -294,7 +295,7 @@ impl ProvideCredential for ECSCredentialProvider {
                 .with_context(format!("endpoint: {endpoint}"))
         })?;
 
-        let expires_in = creds.expiration.parse().map_err(|e| {
+        let expires_in = Timestamp::parse_timestamp(&creds.expiration).map_err(|e| {
             Error::unexpected("failed to parse ECS credential expiration")
                 .with_source(e)
                 .with_context(format!("expiration_value: {}", creds.expiration))

--- a/services/aws-v4/src/provide_credential/imds.rs
+++ b/services/aws-v4/src/provide_credential/imds.rs
@@ -244,7 +244,7 @@ impl ProvideCredential for IMDSv2CredentialProvider {
             access_key_id: resp.access_key_id,
             secret_access_key: resp.secret_access_key,
             session_token: Some(resp.token),
-            expires_in: Some(Timestamp::parse_timestamp(&resp.expiration).map_err(|e| {
+            expires_in: Some(resp.expiration.parse().map_err(|e| {
                 Error::unexpected("failed to parse IMDS credential expiration time")
                     .with_source(e)
                     .with_context(format!("expiration_value: {}", resp.expiration))

--- a/services/aws-v4/src/provide_credential/process.rs
+++ b/services/aws-v4/src/provide_credential/process.rs
@@ -19,7 +19,6 @@ use crate::Credential;
 use async_trait::async_trait;
 use ini::Ini;
 use log::debug;
-use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result};
 use serde::Deserialize;
 
@@ -210,13 +209,9 @@ impl ProvideCredential for ProcessCredentialProvider {
         };
 
         let output = self.execute_process(ctx, &command).await?;
-
-        let expires_in = if let Some(exp_str) = &output.expiration {
-            Some(Timestamp::parse_timestamp(exp_str)?)
-        } else {
-            None
-        };
-
+        let expires_in = output
+            .expiration
+            .and_then(|expires_in| expires_in.parse().ok());
         Ok(Some(Credential {
             access_key_id: output.access_key_id,
             secret_access_key: output.secret_access_key,

--- a/services/aws-v4/src/provide_credential/process.rs
+++ b/services/aws-v4/src/provide_credential/process.rs
@@ -211,14 +211,11 @@ impl ProvideCredential for ProcessCredentialProvider {
 
         let output = self.execute_process(ctx, &command).await?;
 
-        let expires_in =
-            if let Some(exp_str) = &output.expiration {
-                Some(exp_str.parse::<Timestamp>().map_err(|e| {
-                    Error::unexpected(format!("failed to parse expiration time: {e}"))
-                })?)
-            } else {
-                None
-            };
+        let expires_in = if let Some(exp_str) = &output.expiration {
+            Some(Timestamp::parse_timestamp(exp_str)?)
+        } else {
+            None
+        };
 
         Ok(Some(Credential {
             access_key_id: output.access_key_id,

--- a/services/aws-v4/src/provide_credential/s3_express_session.rs
+++ b/services/aws-v4/src/provide_credential/s3_express_session.rs
@@ -20,7 +20,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Method, Request, header};
 use log::debug;
-use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result, SignRequest};
 use serde::Deserialize;
 
@@ -160,7 +159,10 @@ impl S3ExpressSessionProvider {
             })?;
 
         // Parse expiration time from ISO8601 format
-        let expiration = Timestamp::parse_timestamp(&create_session_resp.credentials.expiration)
+        let expiration = create_session_resp
+            .credentials
+            .expiration
+            .parse()
             .map_err(|e| {
                 Error::unexpected(format!(
                     "failed to parse expiration time '{}': {e}",

--- a/services/aws-v4/src/provide_credential/s3_express_session.rs
+++ b/services/aws-v4/src/provide_credential/s3_express_session.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Method, Request, header};
 use log::debug;
-use reqsign_core::time::parse_rfc3339;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result, SignRequest};
 use serde::Deserialize;
 
@@ -160,10 +160,10 @@ impl S3ExpressSessionProvider {
             })?;
 
         // Parse expiration time from ISO8601 format
-        let expiration =
-            parse_rfc3339(&create_session_resp.credentials.expiration).map_err(|e| {
+        let expiration = Timestamp::parse_timestamp(&create_session_resp.credentials.expiration)
+            .map_err(|e| {
                 Error::unexpected(format!(
-                    "Failed to parse expiration time '{}': {e}",
+                    "failed to parse expiration time '{}': {e}",
                     create_session_resp.credentials.expiration
                 ))
             })?;

--- a/services/aws-v4/src/provide_credential/sso.rs
+++ b/services/aws-v4/src/provide_credential/sso.rs
@@ -218,7 +218,7 @@ impl SSOCredentialProvider {
                 })?;
 
                 // Check if token is expired
-                let expires_at = Timestamp::parse_timestamp(&token.expires_at)?;
+                let expires_at = token.expires_at.parse::<Timestamp>()?;
                 if expires_at <= Timestamp::now() {
                     warn!("SSO token is expired");
                     return Ok(None);

--- a/services/aws-v4/src/provide_credential/sso.rs
+++ b/services/aws-v4/src/provide_credential/sso.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use http::{Method, Request, StatusCode};
 use ini::Ini;
 use log::{debug, warn};
-use reqsign_core::time::{Timestamp, now};
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Error, ProvideCredential, Result};
 use serde::Deserialize;
 
@@ -218,11 +218,8 @@ impl SSOCredentialProvider {
                 })?;
 
                 // Check if token is expired
-                let expires_at = token.expires_at.parse::<Timestamp>().map_err(|e| {
-                    Error::unexpected(format!("failed to parse expiration time: {e}"))
-                })?;
-
-                if expires_at <= now() {
+                let expires_at = Timestamp::parse_timestamp(&token.expires_at)?;
+                if expires_at <= Timestamp::now() {
                     warn!("SSO token is expired");
                     return Ok(None);
                 }

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -33,7 +33,6 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 form_urlencoded = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 log = { workspace = true }
 percent-encoding = { workspace = true }
 reqsign-core = { workspace = true }

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-azure-storage"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "Azure Storage signing implementation for reqsign."
 

--- a/services/azure-storage/src/credential.rs
+++ b/services/azure-storage/src/credential.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use reqsign_core::SigningCredential;
-use reqsign_core::time::{Timestamp, now};
+use reqsign_core::time::Timestamp;
 use reqsign_core::utils::Redact;
 use std::fmt::{Debug, Formatter};
+use std::time::Duration;
 
 /// Credential enum for different Azure Storage authentication methods.
 #[derive(Clone)]
@@ -82,7 +83,7 @@ impl SigningCredential for Credential {
                 }
                 // Check expiration for bearer tokens (take 20s as buffer to avoid edge cases)
                 if let Some(expires) = expires_in {
-                    *expires > now() + jiff::SignedDuration::from_secs(20)
+                    *expires > Timestamp::now() + Duration::from_secs(20)
                 } else {
                     true
                 }

--- a/services/azure-storage/src/provide_credential/azure_cli.rs
+++ b/services/azure-storage/src/provide_credential/azure_cli.rs
@@ -96,13 +96,9 @@ impl ProvideCredential for AzureCliCredentialProvider {
 
         // Calculate expiration time
         let expires_on = if let Some(timestamp) = token.expires_on_timestamp {
-            Some(Timestamp::from_second(timestamp).unwrap())
+            Timestamp::from_second(timestamp).ok()
         } else if let Some(expires_str) = token.expires_on {
-            // Parse the string format "2023-10-31 21:59:10.000000"
-            expires_str
-                .parse::<jiff::civil::DateTime>()
-                .and_then(|dt| jiff::tz::TimeZone::UTC.to_timestamp(dt))
-                .ok()
+            Timestamp::parse_datetime_utc(&expires_str).ok()
         } else {
             None
         };

--- a/services/azure-storage/src/provide_credential/azure_pipelines.rs
+++ b/services/azure-storage/src/provide_credential/azure_pipelines.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
-
 use crate::credential::Credential;
 use async_trait::async_trait;
-use reqsign_core::time::now;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential};
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::time::Duration;
 
 /// AzurePipelinesCredentialProvider provides credentials using Azure Pipelines workload identity
 ///
@@ -233,12 +233,12 @@ impl ProvideCredential for AzurePipelinesCredentialProvider {
             .await?;
 
         // Calculate expiration time
-        let expires_in = std::time::Duration::from_secs(token_response.expires_in);
-        let expires_on = now().checked_add(expires_in).ok();
+        let expires_in = Duration::from_secs(token_response.expires_in);
+        let expires_on = Timestamp::now() + expires_in;
 
         Ok(Some(Credential::with_bearer_token(
             &token_response.access_token,
-            expires_on,
+            Some(expires_on),
         )))
     }
 }

--- a/services/azure-storage/src/provide_credential/client_certificate.rs
+++ b/services/azure-storage/src/provide_credential/client_certificate.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
-use reqsign_core::time::now;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential};
 use rsa::RsaPrivateKey;
 use rsa::pkcs8::DecodePrivateKey;
@@ -315,12 +315,11 @@ impl ProvideCredential for ClientCertificateCredentialProvider {
             .await?;
 
         // Calculate expiration time
-        let expires_in = Duration::from_secs(token_response.expires_in);
-        let expires_on = now().checked_add(expires_in).ok();
+        let expires_on = Timestamp::now() + Duration::from_secs(token_response.expires_in);
 
         Ok(Some(Credential::with_bearer_token(
             &token_response.access_token,
-            expires_on,
+            Some(expires_on),
         )))
     }
 }

--- a/services/azure-storage/src/provide_credential/client_secret.rs
+++ b/services/azure-storage/src/provide_credential/client_secret.rs
@@ -17,7 +17,9 @@
 
 use crate::Credential;
 use async_trait::async_trait;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential, Result};
+use std::time::Duration;
 
 /// Load credential from Azure Client Secret.
 ///
@@ -90,9 +92,7 @@ impl ProvideCredential for ClientSecretCredentialProvider {
 
         match token {
             Some(token_response) => {
-                let expires_on = reqsign_core::time::now()
-                    + jiff::SignedDuration::from_secs(token_response.expires_in as i64);
-
+                let expires_on = Timestamp::now() + Duration::from_secs(token_response.expires_in);
                 Ok(Some(Credential::with_bearer_token(
                     &token_response.access_token,
                     Some(expires_on),

--- a/services/azure-storage/src/provide_credential/imds.rs
+++ b/services/azure-storage/src/provide_credential/imds.rs
@@ -19,6 +19,7 @@ use crate::Credential;
 use async_trait::async_trait;
 use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential, Result};
+use std::time::Duration;
 
 /// Load credential from Azure Instance Metadata Service (IMDS).
 ///
@@ -52,7 +53,7 @@ impl ProvideCredential for ImdsCredentialProvider {
         let token = get_access_token("https://storage.azure.com/", ctx).await?;
 
         let expires_on = if token.expires_on.is_empty() {
-            reqsign_core::time::now() + jiff::SignedDuration::from_mins(10)
+            Timestamp::now() + Duration::from_secs(600)
         } else {
             // Azure IMDS returns expires_on as Unix timestamp (seconds since epoch)
             let timestamp = token.expires_on.parse::<i64>().map_err(|e| {

--- a/services/azure-storage/src/provide_credential/workload_identity.rs
+++ b/services/azure-storage/src/provide_credential/workload_identity.rs
@@ -87,7 +87,7 @@ impl ProvideCredential for WorkloadIdentityCredentialProvider {
         match token {
             Some(token_response) => {
                 let expires_on = match token_response.expires_on {
-                    Some(expires_on) => Timestamp::parse_timestamp(&expires_on).map_err(|e| {
+                    Some(expires_on) => expires_on.parse().map_err(|e| {
                         reqsign_core::Error::unexpected("failed to parse expires_on time")
                             .with_source(e)
                     })?,

--- a/services/azure-storage/src/provide_credential/workload_identity.rs
+++ b/services/azure-storage/src/provide_credential/workload_identity.rs
@@ -17,7 +17,9 @@
 
 use crate::Credential;
 use async_trait::async_trait;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential, Result};
+use std::time::Duration;
 
 /// Load credential from Azure Workload Identity.
 ///
@@ -85,13 +87,11 @@ impl ProvideCredential for WorkloadIdentityCredentialProvider {
         match token {
             Some(token_response) => {
                 let expires_on = match token_response.expires_on {
-                    Some(expires_on) => {
-                        reqsign_core::time::parse_rfc3339(&expires_on).map_err(|e| {
-                            reqsign_core::Error::unexpected("failed to parse expires_on time")
-                                .with_source(e)
-                        })?
-                    }
-                    None => reqsign_core::time::now() + jiff::SignedDuration::from_mins(10),
+                    Some(expires_on) => Timestamp::parse_timestamp(&expires_on).map_err(|e| {
+                        reqsign_core::Error::unexpected("failed to parse expires_on time")
+                            .with_source(e)
+                    })?,
+                    None => Timestamp::now() + Duration::from_secs(600),
                 };
 
                 Ok(Some(Credential::with_bearer_token(

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -29,7 +29,6 @@ rust-version.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 jsonwebtoken = "9.2"
 log = { workspace = true }
 percent-encoding = { workspace = true }

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-google"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "Goole Cloud Platform signing implementation for reqsign."
 

--- a/services/google/src/provide_credential/authorized_user.rs
+++ b/services/google/src/provide_credential/authorized_user.rs
@@ -18,10 +18,11 @@
 use http::header::CONTENT_TYPE;
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
-
-use reqsign_core::{Context, ProvideCredential, Result, time::now};
+use std::time::Duration;
 
 use crate::credential::{Credential, OAuth2Credentials, Token};
+use reqsign_core::time::Timestamp;
+use reqsign_core::{Context, ProvideCredential, Result};
 
 /// OAuth2 refresh token request.
 #[derive(Serialize)]
@@ -96,13 +97,11 @@ impl ProvideCredential for AuthorizedUserCredentialProvider {
 
         let expires_at = token_resp
             .expires_in
-            .map(|expires_in| now() + jiff::SignedDuration::from_secs(expires_in as i64));
+            .map(|expires_in| Timestamp::now() + Duration::from_secs(expires_in));
 
-        let token = Token {
+        Ok(Some(Credential::with_token(Token {
             access_token: token_resp.access_token,
             expires_at,
-        };
-
-        Ok(Some(Credential::with_token(token)))
+        })))
     }
 }

--- a/services/google/src/provide_credential/external_account.rs
+++ b/services/google/src/provide_credential/external_account.rs
@@ -247,11 +247,9 @@ impl ExternalAccountCredentialProvider {
             })?;
 
         // Parse expire time from RFC3339 format
-        let expires_at = Timestamp::parse_timestamp(&token_resp.expire_time).ok();
-
         Ok(Some(Token {
             access_token: token_resp.access_token,
-            expires_at,
+            expires_at: token_resp.expire_time.parse().ok(),
         }))
     }
 }

--- a/services/google/src/provide_credential/external_account.rs
+++ b/services/google/src/provide_credential/external_account.rs
@@ -22,8 +22,8 @@ use log::{debug, error};
 use serde::{Deserialize, Serialize};
 
 use crate::credential::{Credential, ExternalAccount, Token, external_account};
-use reqsign_core::time::parse_rfc3339;
-use reqsign_core::{Context, ProvideCredential, Result, time::now};
+use reqsign_core::time::Timestamp;
+use reqsign_core::{Context, ProvideCredential, Result};
 
 /// The maximum impersonated token lifetime allowed, 1 hour.
 const MAX_LIFETIME: Duration = Duration::from_secs(3600);
@@ -178,7 +178,7 @@ impl ExternalAccountCredentialProvider {
 
         let expires_at = token_resp
             .expires_in
-            .map(|expires_in| now() + jiff::SignedDuration::from_secs(expires_in as i64));
+            .map(|expires_in| Timestamp::now() + Duration::from_secs(expires_in));
 
         Ok(Token {
             access_token: token_resp.access_token,
@@ -247,7 +247,7 @@ impl ExternalAccountCredentialProvider {
             })?;
 
         // Parse expire time from RFC3339 format
-        let expires_at = parse_rfc3339(&token_resp.expire_time).ok();
+        let expires_at = Timestamp::parse_timestamp(&token_resp.expire_time).ok();
 
         Ok(Some(Token {
             access_token: token_resp.access_token,

--- a/services/google/src/provide_credential/impersonated_service_account.rs
+++ b/services/google/src/provide_credential/impersonated_service_account.rs
@@ -22,8 +22,8 @@ use log::{debug, error};
 use serde::{Deserialize, Serialize};
 
 use crate::credential::{Credential, ImpersonatedServiceAccount, Token};
-use reqsign_core::time::parse_rfc3339;
-use reqsign_core::{Context, ProvideCredential, Result, time::now};
+use reqsign_core::time::Timestamp;
+use reqsign_core::{Context, ProvideCredential, Result};
 
 /// The maximum impersonated token lifetime allowed, 1 hour.
 const MAX_LIFETIME: Duration = Duration::from_secs(3600);
@@ -137,7 +137,7 @@ impl ImpersonatedServiceAccountCredentialProvider {
 
         let expires_at = token_resp
             .expires_in
-            .map(|expires_in| now() + jiff::SignedDuration::from_secs(expires_in as i64));
+            .map(|expires_in| Timestamp::now() + Duration::from_secs(expires_in));
 
         Ok(Token {
             access_token: token_resp.access_token,
@@ -200,7 +200,7 @@ impl ImpersonatedServiceAccountCredentialProvider {
             })?;
 
         // Parse expire time from RFC3339 format
-        let expires_at = parse_rfc3339(&token_resp.expire_time).ok();
+        let expires_at = Timestamp::parse_timestamp(&token_resp.expire_time).ok();
 
         Ok(Token {
             access_token: token_resp.access_token,

--- a/services/google/src/provide_credential/impersonated_service_account.rs
+++ b/services/google/src/provide_credential/impersonated_service_account.rs
@@ -200,11 +200,9 @@ impl ImpersonatedServiceAccountCredentialProvider {
             })?;
 
         // Parse expire time from RFC3339 format
-        let expires_at = Timestamp::parse_timestamp(&token_resp.expire_time).ok();
-
         Ok(Token {
             access_token: token_resp.access_token,
-            expires_at,
+            expires_at: token_resp.expire_time.parse().ok(),
         })
     }
 }

--- a/services/google/src/provide_credential/vm_metadata.rs
+++ b/services/google/src/provide_credential/vm_metadata.rs
@@ -17,10 +17,11 @@
 
 use log::debug;
 use serde::Deserialize;
-
-use reqsign_core::{Context, ProvideCredential, Result, time::now};
+use std::time::Duration;
 
 use crate::credential::{Credential, Token};
+use reqsign_core::time::Timestamp;
+use reqsign_core::{Context, ProvideCredential, Result};
 
 /// VM metadata token response.
 #[derive(Deserialize)]
@@ -106,13 +107,10 @@ impl ProvideCredential for VmMetadataCredentialProvider {
                     .with_source(e)
             })?;
 
-        let expires_at = now() + jiff::SignedDuration::from_secs(token_resp.expires_in as i64);
-
-        let token = Token {
+        let expires_at = Timestamp::now() + Duration::from_secs(token_resp.expires_in);
+        Ok(Some(Credential::with_token(Token {
             access_token: token_resp.access_token,
             expires_at: Some(expires_at),
-        };
-
-        Ok(Some(Credential::with_token(token)))
+        })))
     }
 }

--- a/services/huaweicloud-obs/Cargo.toml
+++ b/services/huaweicloud-obs/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-huaweicloud-obs"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "Huawei Cloud OBS signing implementation for reqsign."
 

--- a/services/huaweicloud-obs/Cargo.toml
+++ b/services/huaweicloud-obs/Cargo.toml
@@ -30,7 +30,6 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 log = { workspace = true }
 percent-encoding = { workspace = true }
 reqsign-core = { workspace = true }

--- a/services/oracle/Cargo.toml
+++ b/services/oracle/Cargo.toml
@@ -31,7 +31,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 log = { workspace = true }
 reqsign-core = { workspace = true }
 rsa = { workspace = true }

--- a/services/oracle/Cargo.toml
+++ b/services/oracle/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-oracle"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "Oracle Cloud signing implementation for reqsign."
 

--- a/services/oracle/src/credential.rs
+++ b/services/oracle/src/credential.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use reqsign_core::SigningCredential;
-use reqsign_core::time::{Timestamp, now};
+use reqsign_core::time::Timestamp;
 use reqsign_core::utils::Redact;
 use std::fmt::{Debug, Formatter};
+use std::time::Duration;
 
 /// Credential that holds the API private key information.
 #[derive(Default, Clone)]
@@ -59,7 +60,7 @@ impl SigningCredential for Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + jiff::SignedDuration::from_mins(2))
+            .map(|v| v > Timestamp::now() + Duration::from_secs(120))
         {
             return valid;
         }

--- a/services/oracle/src/provide_credential/config.rs
+++ b/services/oracle/src/provide_credential/config.rs
@@ -20,8 +20,10 @@
 use crate::{Config, Credential};
 use async_trait::async_trait;
 use log::debug;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential, Result};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Static configuration based loader.
 #[derive(Debug)]
@@ -62,9 +64,7 @@ impl ProvideCredential for ConfigCredentialProvider {
                     key_file: key_file.clone(),
                     fingerprint: fingerprint.clone(),
                     // Set expires_in to 10 minutes to enforce re-read
-                    expires_in: Some(
-                        reqsign_core::time::now() + jiff::SignedDuration::from_mins(10),
-                    ),
+                    expires_in: Some(Timestamp::now() + Duration::from_secs(600)),
                 }))
             }
             _ => {

--- a/services/oracle/src/provide_credential/config_file.rs
+++ b/services/oracle/src/provide_credential/config_file.rs
@@ -21,7 +21,9 @@ use crate::constants::{
 };
 use async_trait::async_trait;
 use log::debug;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential, Result};
+use std::time::Duration;
 
 /// ConfigFileCredentialProvider loads credentials from Oracle config file (~/.oci/config).
 ///
@@ -108,9 +110,7 @@ impl ProvideCredential for ConfigFileCredentialProvider {
                     user: user.to_string(),
                     key_file: expanded_key_file,
                     fingerprint: fingerprint.to_string(),
-                    expires_in: Some(
-                        reqsign_core::time::now() + jiff::SignedDuration::from_mins(10),
-                    ),
+                    expires_in: Some(Timestamp::now() + Duration::from_secs(600)),
                 }))
             }
             _ => {

--- a/services/oracle/src/provide_credential/env.rs
+++ b/services/oracle/src/provide_credential/env.rs
@@ -17,7 +17,9 @@
 
 use crate::{Credential, constants::*};
 use async_trait::async_trait;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential, Result};
+use std::time::Duration;
 
 /// EnvCredentialProvider loads Oracle Cloud credentials from environment variables.
 ///
@@ -64,9 +66,7 @@ impl ProvideCredential for EnvCredentialProvider {
                     tenancy: tenancy.clone(),
                     key_file: expanded_key_file,
                     fingerprint: fingerprint.clone(),
-                    expires_in: Some(
-                        reqsign_core::time::now() + jiff::SignedDuration::from_mins(10),
-                    ),
+                    expires_in: Some(Timestamp::now() + Duration::from_secs(600)),
                 }))
             }
             _ => Ok(None),

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-tencent-cos"
-version = "1.1.0"
+version = "2.0.0"
 
 description = "Tencent Cloud COS signing implementation for reqsign."
 

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -30,7 +30,6 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 http = { workspace = true }
-jiff = { workspace = true }
 log = { workspace = true }
 percent-encoding = { workspace = true }
 reqsign-core = { workspace = true }

--- a/services/tencent-cos/src/credential.rs
+++ b/services/tencent-cos/src/credential.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use reqsign_core::SigningCredential;
-use reqsign_core::time::{Timestamp, now};
+use reqsign_core::time::Timestamp;
 use reqsign_core::utils::Redact;
 use std::fmt::{Debug, Formatter};
+use std::time::Duration;
 
 /// Credential for Tencent COS.
 #[derive(Default, Clone)]
@@ -52,7 +53,7 @@ impl SigningCredential for Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + jiff::SignedDuration::from_mins(2))
+            .map(|v| v > Timestamp::now() + Duration::from_secs(120))
         {
             return valid;
         }

--- a/services/tencent-cos/src/provide_credential/assume_role_with_web_identity.rs
+++ b/services/tencent-cos/src/provide_credential/assume_role_with_web_identity.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use http::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
 use log::debug;
 use reqsign_core::Result;
-use reqsign_core::time::{now, parse_rfc3339};
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, ProvideCredential};
 use serde::{Deserialize, Serialize};
 
@@ -110,7 +110,7 @@ impl ProvideCredential for AssumeRoleWithWebIdentityCredentialProvider {
             .header(CONTENT_LENGTH, bs.len())
             .header("X-TC-Action", "AssumeRoleWithWebIdentity")
             .header("X-TC-Region", &region)
-            .header("X-TC-Timestamp", now().as_second())
+            .header("X-TC-Timestamp", Timestamp::now().as_second())
             .header("X-TC-Version", "2018-08-13")
             .body(bs.into())?;
 
@@ -140,7 +140,7 @@ impl ProvideCredential for AssumeRoleWithWebIdentityCredentialProvider {
             secret_id: resp_cred.tmp_secret_id,
             secret_key: resp_cred.tmp_secret_key,
             security_token: Some(resp_cred.token),
-            expires_in: Some(parse_rfc3339(&resp_expiration)?),
+            expires_in: Some(Timestamp::parse_timestamp(&resp_expiration)?),
         };
 
         Ok(Some(cred))

--- a/services/tencent-cos/src/provide_credential/assume_role_with_web_identity.rs
+++ b/services/tencent-cos/src/provide_credential/assume_role_with_web_identity.rs
@@ -140,7 +140,7 @@ impl ProvideCredential for AssumeRoleWithWebIdentityCredentialProvider {
             secret_id: resp_cred.tmp_secret_id,
             secret_key: resp_cred.tmp_secret_key,
             security_token: Some(resp_cred.token),
-            expires_in: Some(Timestamp::parse_timestamp(&resp_expiration)?),
+            expires_in: Some(resp_expiration.parse()?),
         };
 
         Ok(Some(cred))

--- a/services/tencent-cos/tests/credential_chain.rs
+++ b/services/tencent-cos/tests/credential_chain.rs
@@ -19,11 +19,13 @@
 
 use async_trait::async_trait;
 use reqsign_core::ProvideCredentialChain;
+use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, OsEnv, ProvideCredential, Result};
 use reqsign_file_read_tokio::TokioFileRead;
 use reqsign_http_send_reqwest::ReqwestHttpSend;
 use reqsign_tencent_cos::{Credential, EnvCredentialProvider};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Mock provider that tracks how many times it was called
 #[derive(Debug)]
@@ -199,7 +201,7 @@ impl ProvideCredential for SecurityTokenProvider {
             secret_id: "temp_id".to_string(),
             secret_key: "temp_key".to_string(),
             security_token: Some("security_token".to_string()),
-            expires_in: Some(reqsign_core::time::now() + jiff::SignedDuration::from_hours(1)),
+            expires_in: Some(Timestamp::now() + Duration::from_secs(3600)),
         }))
     }
 }


### PR DESCRIPTION
We are now tightly coupled with `jiff`.

I don't see we can encapsulate jiff entirely. Perhaps either:

* `pub extern crate jiff as jiff02` and add a `jiff02` feature flag
* Hide jiff Timestamp behind `pub struct reqsign_core::Timestamp(jiff:Timestamp)`, and expose methods as needed, like adding a duration, parsing/print specific timestamp format, etc.