### PR TITLE
Clarify Azure version header ownership

### DIFF
--- a/services/azure-storage/src/sign_request.rs
+++ b/services/azure-storage/src/sign_request.rs
@@ -465,8 +465,11 @@ fn infer_account_name(authority: &str) -> Result<String> {
 /// CanonicalizedResource;
 /// ```
 /// ## Note
-/// For sub-requests of batch API, requests should be signed without `x-ms-version` header.
-/// Set the `omit_service_version` to `ture` for such.
+///
+/// Reqsign signs the Azure service headers already present on the request.
+/// Callers should include `x-ms-version` for ordinary Azure Storage requests,
+/// but omit it for batch API sub-requests, which Azure requires to be signed
+/// without that header.
 ///
 /// ## Reference
 ///


### PR DESCRIPTION
Reqsign no longer owns Azure service-version header insertion. Document
that callers should provide `x-ms-version` for ordinary Azure Storage
requests and omit it only for batch sub-requests.

This changed in aa28ce2e4db673c6f0fa9fc31533b39e856ad825.
