### PR TITLE
make aws-lc-rs optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,17 +164,55 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [aws-lc-rs, rust-crypto]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Test
-        run: cargo test --no-fail-fast
+
+      # Backend-agnostic crates: only run once (aws-lc-rs leg) to avoid
+      # re-running identical work in the rust-crypto leg.
+      - name: Test (backend-agnostic crates)
+        if: matrix.backend == 'aws-lc-rs'
+        run: |
+          cargo test --no-fail-fast --workspace \
+            --exclude reqsign-google \
+            --exclude reqsign-azure-storage \
+            --exclude reqsign
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
-      - name: Doc Test
+
+      - name: Doc Test (backend-agnostic, --all-features)
+        if: matrix.backend == 'aws-lc-rs'
         run: cargo test --doc --all-features --workspace
+        env:
+          RUST_LOG: DEBUG
+          RUST_BACKTRACE: full
+
+      - name: Test (JWT crates + facade, backend=${{ matrix.backend }})
+        run: |
+          cargo test --no-fail-fast -p reqsign-google \
+            --no-default-features --features ${{ matrix.backend }}
+          cargo test --no-fail-fast -p reqsign-azure-storage \
+            --no-default-features --features ${{ matrix.backend }}
+          cargo test --no-fail-fast -p reqsign \
+            --no-default-features --features default-context,full,${{ matrix.backend }}
+        env:
+          RUST_LOG: DEBUG
+          RUST_BACKTRACE: full
+
+      - name: Doc Test (backend=${{ matrix.backend }})
+        run: |
+          cargo test --doc --no-fail-fast -p reqsign-google \
+            --no-default-features --features ${{ matrix.backend }}
+          cargo test --doc --no-fail-fast -p reqsign-azure-storage \
+            --no-default-features --features ${{ matrix.backend }}
+          cargo test --doc --no-fail-fast -p reqsign \
+            --no-default-features --features default-context,full,${{ matrix.backend }}
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,68 @@ jobs:
           cargo build --manifest-path reqsign/Cargo.toml --target wasm32-unknown-unknown --no-default-features --features=aws,azure,aliyun,tencent
           cargo build --manifest-path reqsign/Cargo.toml --target wasm32-unknown-unknown --no-default-features --features=default-context,aws,azure,aliyun,tencent
 
+  # Regression guard: walk every workspace member and assert that
+  # `aws-lc-rs` is absent from its non-dev dep graph. Crates that ship a
+  # `rust-crypto` backend selector (`reqsign-google`,
+  # `reqsign-azure-storage`, and the `reqsign` facade) are exercised with
+  # `--no-default-features --features rust-crypto`; everything else is
+  # exercised with default features.
+  #
+  # `cargo tree -e normal,build -i aws-lc-rs` prints non-empty stdout only
+  # when `aws-lc-rs` is reachable through a normal or build edge. Dev-only
+  # paths are deliberately ignored; they do not ship to downstream users.
+  crypto_backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build pure-Rust facade (rust-crypto across google + azure)
+        run: |
+          cargo build --manifest-path reqsign/Cargo.toml --no-default-features \
+            --features default-context,google,azure,rust-crypto
+
+      - name: Walk every workspace crate and assert aws-lc-rs is absent
+        shell: bash
+        run: |
+          set -u
+          fail=0
+
+          # Empty stdout from `cargo tree -i` means the target package is
+          # unreachable on the selected feature set + edge filter.
+          check_absent() {
+            local label="$1"; shift
+            local out
+            out=$(cargo tree "$@" -e normal,build -i aws-lc-rs 2>/dev/null || true)
+            if [ -n "$out" ]; then
+              echo "::error::${label}: aws-lc-rs unexpectedly in non-dev dep graph"
+              printf '%s\n' "$out"
+              fail=1
+            else
+              echo "ok ${label}: aws-lc-rs absent"
+            fi
+          }
+
+          packages=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          for pkg in $packages; do
+            case "$pkg" in
+              reqsign-google|reqsign-azure-storage)
+                check_absent "$pkg (rust-crypto)" -p "$pkg" \
+                  --no-default-features --features rust-crypto
+                ;;
+              reqsign)
+                check_absent "$pkg (rust-crypto)" -p "$pkg" \
+                  --no-default-features --features default-context,google,azure,rust-crypto
+                ;;
+              *)
+                check_absent "$pkg (default)" -p "$pkg"
+                ;;
+            esac
+          done
+
+          exit $fail
+
   unit:
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,14 @@ rust-version = "1.85.0"
 # Workspace dependencies
 reqsign-aliyun-oss = { version = "3.0.0", path = "services/aliyun-oss" }
 reqsign-aws-v4 = { version = "3.0.0", path = "services/aws-v4" }
-reqsign-azure-storage = { version = "3.0.0", path = "services/azure-storage" }
+# Crypto backend (aws-lc-rs vs rust-crypto) for jsonwebtoken users is
+# selected by the facade or end-consumer; disable defaults here so that
+# feature unification across workspace members doesn't lock aws-lc-rs in.
+reqsign-azure-storage = { version = "3.0.0", path = "services/azure-storage", default-features = false }
 reqsign-command-execute-tokio = { version = "3.0.0", path = "context/command-execute-tokio" }
 reqsign-core = { version = "3.0.0", path = "core" }
 reqsign-file-read-tokio = { version = "3.0.0", path = "context/file-read-tokio" }
-reqsign-google = { version = "3.0.0", path = "services/google" }
+reqsign-google = { version = "3.0.0", path = "services/google", default-features = false }
 reqsign-http-send-reqwest = { version = "4.0.0", path = "context/http-send-reqwest" }
 reqsign-huaweicloud-obs = { version = "3.0.0", path = "services/huaweicloud-obs" }
 reqsign-oracle = { version = "3.0.0", path = "services/oracle" }
@@ -53,7 +56,7 @@ hex = "0.4"
 hmac = "0.13"
 http = "1"
 jiff = "0.2"
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10", default-features = false, features = ["use_pem"] }
 log = "0.4"
 percent-encoding = "2"
 pretty_assertions = "1.3"

--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -52,11 +52,23 @@ reqsign-file-read-tokio = { workspace = true, optional = true }
 reqsign-http-send-reqwest = { workspace = true, optional = true }
 
 [features]
-default = ["default-context"]
+default = ["default-context", "aws-lc-rs"]
 default-context = [
   "dep:reqsign-command-execute-tokio",
   "dep:reqsign-file-read-tokio",
   "dep:reqsign-http-send-reqwest",
+]
+
+# Crypto backend selection for services that use jsonwebtoken (google, azure).
+# These are pass-through to the underlying service crates and a no-op when
+# neither service is enabled.
+aws-lc-rs = [
+  "reqsign-google?/aws-lc-rs",
+  "reqsign-azure-storage?/aws-lc-rs",
+]
+rust-crypto = [
+  "reqsign-google?/rust-crypto",
+  "reqsign-azure-storage?/rust-crypto",
 ]
 
 # Service features

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -26,6 +26,11 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["aws-lc-rs"]
+aws-lc-rs = ["jsonwebtoken/aws_lc_rs"]
+rust-crypto = ["jsonwebtoken/rust_crypto"]
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -26,6 +26,11 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["aws-lc-rs"]
+aws-lc-rs = ["jsonwebtoken/aws_lc_rs"]
+rust-crypto = ["jsonwebtoken/rust_crypto"]
+
 [dependencies]
 form_urlencoded = { workspace = true }
 http = { workspace = true }


### PR DESCRIPTION
Closes #754

https://github.com/apache/opendal-reqsign/pull/689 updated `jsonwebtoken` and enabled the `aws-lc-rs` feature.

This makes the crypto backend configurable by adding the `rust-crypto` and `aws-lc-rs` features. `aws-lc-rs` is kept as the default. To select a different backend, you need to disable the default features and enable the respective backend (e.g. `rust-cypto`). This allows downstream users to avoid pulling in `aws-lc-rs`.

I also added two CI changes. First, a regression test to avoid that aws-lc-rs sneaks back in accidentally using `cargo tree`. Second, unit tests now run against both backend features to catch any bugs that only occur in one backend.