### PR TITLE
chore: prepare v0.20.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,18 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-reqsign-aliyun-oss = { version = "3.0.0", path = "services/aliyun-oss" }
-reqsign-aws-v4 = { version = "3.0.0", path = "services/aws-v4" }
-reqsign-azure-storage = { version = "3.0.0", path = "services/azure-storage" }
-reqsign-command-execute-tokio = { version = "3.0.0", path = "context/command-execute-tokio" }
-reqsign-core = { version = "3.0.0", path = "core" }
-reqsign-file-read-tokio = { version = "3.0.0", path = "context/file-read-tokio" }
-reqsign-google = { version = "3.0.0", path = "services/google" }
-reqsign-http-send-reqwest = { version = "4.0.0", path = "context/http-send-reqwest" }
-reqsign-huaweicloud-obs = { version = "3.0.0", path = "services/huaweicloud-obs" }
-reqsign-oracle = { version = "3.0.0", path = "services/oracle" }
-reqsign-tencent-cos = { version = "3.0.0", path = "services/tencent-cos" }
-reqsign-volcengine-tos = { version = "3.0.0", path = "services/volcengine-tos" }
+reqsign-aliyun-oss = { version = "3.1.0", path = "services/aliyun-oss" }
+reqsign-aws-v4 = { version = "3.0.1", path = "services/aws-v4" }
+reqsign-azure-storage = { version = "3.0.1", path = "services/azure-storage" }
+reqsign-command-execute-tokio = { version = "3.0.1", path = "context/command-execute-tokio" }
+reqsign-core = { version = "3.0.1", path = "core" }
+reqsign-file-read-tokio = { version = "3.0.1", path = "context/file-read-tokio" }
+reqsign-google = { version = "3.0.1", path = "services/google" }
+reqsign-http-send-reqwest = { version = "4.0.1", path = "context/http-send-reqwest" }
+reqsign-huaweicloud-obs = { version = "3.0.1", path = "services/huaweicloud-obs" }
+reqsign-oracle = { version = "3.0.1", path = "services/oracle" }
+reqsign-tencent-cos = { version = "3.0.1", path = "services/tencent-cos" }
+reqsign-volcengine-tos = { version = "3.0.1", path = "services/volcengine-tos" }
 
 # Crates.io dependencies
 anyhow = "1"

--- a/context/command-execute-tokio/Cargo.toml
+++ b/context/command-execute-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-command-execute-tokio"
-version = "3.0.0"
+version = "3.0.1"
 
 categories = ["asynchronous"]
 description = "Tokio-based command execution implementation for reqsign"

--- a/context/file-read-tokio/Cargo.toml
+++ b/context/file-read-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-file-read-tokio"
-version = "3.0.0"
+version = "3.0.1"
 
 categories = ["asynchronous"]
 description = "Tokio-based file reader implementation for reqsign"

--- a/context/http-send-reqwest/Cargo.toml
+++ b/context/http-send-reqwest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-http-send-reqwest"
-version = "4.0.0"
+version = "4.0.1"
 
 categories = ["asynchronous"]
 description = "Reqwest-based HTTP client implementation for reqsign."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-core"
-version = "3.0.0"
+version = "3.0.1"
 
 categories = ["command-line-utilities", "web-programming"]
 description = "Signing API requests without effort."

--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign"
-version = "0.20.0"
+version = "0.20.1"
 
 categories = ["authentication", "web-programming::http-client"]
 description = "Signing HTTP requests for AWS, Azure, Google, Huawei, Aliyun, Tencent and Oracle services"

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aliyun-oss"
-version = "3.0.0"
+version = "3.1.0"
 
 description = "Aliyun OSS signing implementation for reqsign."
 

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aws-v4"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "AWS SigV4 signing implementation for reqsign."
 

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-azure-storage"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "Azure Storage signing implementation for reqsign."
 

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-google"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "Google Cloud Platform signing implementation for reqsign."
 

--- a/services/huaweicloud-obs/Cargo.toml
+++ b/services/huaweicloud-obs/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-huaweicloud-obs"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "Huawei Cloud OBS signing implementation for reqsign."
 

--- a/services/oracle/Cargo.toml
+++ b/services/oracle/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-oracle"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "Oracle Cloud signing implementation for reqsign."
 

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-tencent-cos"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "Tencent Cloud COS signing implementation for reqsign."
 

--- a/services/volcengine-tos/Cargo.toml
+++ b/services/volcengine-tos/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-volcengine-tos"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "Volcengine TOS signing implementation for reqsign."
 


### PR DESCRIPTION
Prepare the workspace manifests for a future v0.20.1 release candidate. The facade crate is bumped to 0.20.1, Aliyun OSS moves to 3.1.0 for the new signing/configuration surface, and the remaining workspace crates receive patch bumps so the published dependency graph stays aligned.

This PR is not the final release action. The release still needs to follow the Apache release process with signed source artifacts, checksum files, a vote, and only then the formal release tag/publish step.
