### PR TITLE
feat(azure-storage): add missing setters for client secret and workload identity providers

### DIFF
--- a/services/azure-storage/src/provide_credential/client_secret.rs
+++ b/services/azure-storage/src/provide_credential/client_secret.rs
@@ -31,6 +31,8 @@ use std::time::Duration;
 pub struct ClientSecretCredentialProvider {
     tenant_id: Option<String>,
     client_id: Option<String>,
+    client_secret: Option<String>,
+    authority_host: Option<String>,
 }
 
 impl ClientSecretCredentialProvider {
@@ -50,6 +52,18 @@ impl ClientSecretCredentialProvider {
         self.client_id = Some(client_id.into());
         self
     }
+
+    /// Set the client secret.
+    pub fn with_client_secret(mut self, client_secret: impl Into<String>) -> Self {
+        self.client_secret = Some(client_secret.into());
+        self
+    }
+
+    /// Set the authority host.
+    pub fn with_authority_host(mut self, authority_host: impl Into<String>) -> Self {
+        self.authority_host = Some(authority_host.into());
+        self
+    }
 }
 impl ProvideCredential for ClientSecretCredentialProvider {
     type Credential = Credential;
@@ -67,18 +81,28 @@ impl ProvideCredential for ClientSecretCredentialProvider {
             _ => return Ok(None),
         };
 
-        let client_id = match envs.get("AZURE_CLIENT_ID") {
+        let client_id = match self
+            .client_id
+            .as_ref()
+            .or_else(|| envs.get("AZURE_CLIENT_ID"))
+        {
             Some(id) if !id.is_empty() => id,
             _ => return Ok(None),
         };
 
-        let client_secret = match envs.get("AZURE_CLIENT_SECRET") {
+        let client_secret = match self
+            .client_secret
+            .as_ref()
+            .or_else(|| envs.get("AZURE_CLIENT_SECRET"))
+        {
             Some(secret) if !secret.is_empty() => secret,
             _ => return Ok(None),
         };
 
-        let authority_host = envs
-            .get("AZURE_AUTHORITY_HOST")
+        let authority_host = self
+            .authority_host
+            .as_ref()
+            .or_else(|| envs.get("AZURE_AUTHORITY_HOST"))
             .filter(|h| !h.is_empty())
             .map(|s| s.as_str())
             .unwrap_or("https://login.microsoftonline.com");

--- a/services/azure-storage/src/provide_credential/workload_identity.rs
+++ b/services/azure-storage/src/provide_credential/workload_identity.rs
@@ -30,6 +30,9 @@ use std::time::Duration;
 #[derive(Debug, Default, Clone)]
 pub struct WorkloadIdentityCredentialProvider {
     tenant_id: Option<String>,
+    client_id: Option<String>,
+    federated_token_file: Option<String>,
+    authority_host: Option<String>,
 }
 
 impl WorkloadIdentityCredentialProvider {
@@ -43,6 +46,24 @@ impl WorkloadIdentityCredentialProvider {
         self.tenant_id = Some(tenant_id.into());
         self
     }
+
+    /// Set the client ID.
+    pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.client_id = Some(client_id.into());
+        self
+    }
+
+    /// Set the federated token file path.
+    pub fn with_federated_token_file(mut self, path: impl Into<String>) -> Self {
+        self.federated_token_file = Some(path.into());
+        self
+    }
+
+    /// Set the authority host.
+    pub fn with_authority_host(mut self, authority_host: impl Into<String>) -> Self {
+        self.authority_host = Some(authority_host.into());
+        self
+    }
 }
 impl ProvideCredential for WorkloadIdentityCredentialProvider {
     type Credential = Credential;
@@ -51,23 +72,37 @@ impl ProvideCredential for WorkloadIdentityCredentialProvider {
         let envs = ctx.env_vars();
 
         // Check if all required parameters are available from environment
-        let tenant_id = match envs.get("AZURE_TENANT_ID") {
+        let tenant_id = match self
+            .tenant_id
+            .as_ref()
+            .or_else(|| envs.get("AZURE_TENANT_ID"))
+        {
             Some(id) if !id.is_empty() => id,
             _ => return Ok(None),
         };
 
-        let client_id = match envs.get("AZURE_CLIENT_ID") {
+        let client_id = match self
+            .client_id
+            .as_ref()
+            .or_else(|| envs.get("AZURE_CLIENT_ID"))
+        {
             Some(id) if !id.is_empty() => id,
             _ => return Ok(None),
         };
 
-        let federated_token_file = match envs.get("AZURE_FEDERATED_TOKEN_FILE") {
+        let federated_token_file = match self
+            .federated_token_file
+            .as_ref()
+            .or_else(|| envs.get("AZURE_FEDERATED_TOKEN_FILE"))
+        {
             Some(file) if !file.is_empty() => file,
             _ => return Ok(None),
         };
 
-        let authority_host = envs
-            .get("AZURE_AUTHORITY_HOST")
+        let authority_host = self
+            .authority_host
+            .as_ref()
+            .or_else(|| envs.get("AZURE_AUTHORITY_HOST"))
             .filter(|h| !h.is_empty())
             .map(|s| s.as_str())
             .unwrap_or("https://login.microsoftonline.com");


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #756.

## What changes are included in this PR?

`ClientSecretCredentialProvider`:
- Add `client_secret` and `authority_host` fields with corresponding setters.
- `provide_credential` now reads `self.client_id` / `self.client_secret` / `self.authority_host` first, falling back to `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_AUTHORITY_HOST`. Fixes `with_client_id` being a silent no-op.

`WorkloadIdentityCredentialProvider`:
- Add `client_id`, `federated_token_file`, and `authority_host` fields with corresponding setters.
- `provide_credential` now reads each from `self` first, falling back to env vars. Fixes `with_tenant_id` being a silent no-op.

Purely additive — all new fields default to `None`, so existing callers see no behavior change.

## Are there any user-facing changes?

New builder API for downstream crates (opendal azdls/azblob in particular) to inject Azure OAuth2 credentials without resorting to `StaticEnv` fake-env workarounds.