### PR TITLE
chore(deps): Update jsonwebtoken requirement from 9.2 to 10.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ version = "0.16.5"
 all-features = true
 
 [features]
-default = ["reqwest_request", "services-all"]
+default = ["reqwest_request", "services-all", "jwt-rust-crypto"]
 
 native-tls = ["reqwest?/default-tls"]
 rustls = ["reqwest?/rustls-tls"]
+
+# crypto backends for jsonwebtoken, exactly one should be enabled
+jwt-rust-crypto = ["jsonwebtoken?/rust_crypto"]
+jwt-aws-lc-rs = ["jsonwebtoken?/aws_lc_rs"]
 
 # requests that reqwest supports
 reqwest_blocking_request = ["reqwest?/blocking"]
@@ -72,7 +76,7 @@ form_urlencoded = "1"
 hex = "0.4"
 hmac = "0.12"
 http = "1.1"
-jsonwebtoken = { version = "9.2", optional = true }
+jsonwebtoken = { version = "10.3", optional = true }
 log = "0.4"
 once_cell = { version = "1", optional = true }
 percent-encoding = "2"


### PR DESCRIPTION
## Motivation
I noticed that reqsign 0.16.x is optionally pulling in a version of jsonwebtoken flagged with a CVE: CVE-2026-25537. This doesn't have direct security implications because reqsign isn't using vulnerable code paths. This just helps clear up some vulnerability scanner noise for anyone pulling in this version of reqsign. 

If you're interested in making a small dependency bump on the v0.16.x version line, this is a tiny patch to do so!
If not, feel free to close this. Thanks for taking a look in either case!
