### PR TITLE
feat: check credential validity against signature expiration

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::time::Timestamp;
 use crate::{BoxedFuture, Context, MaybeSend, Result};
 use std::fmt::Debug;
 use std::future::Future;
@@ -24,7 +25,15 @@ use std::time::Duration;
 /// SigningCredential is the trait used by signer as the signing credential.
 pub trait SigningCredential: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Check if the signing credential is valid.
+    ///
+    /// Note: this will be removed in favor of `is_valid_at` in a future
+    /// release.
     fn is_valid(&self) -> bool;
+
+    /// Check if the signing credential will be valid at the given timestamp.
+    fn is_valid_at(&self, _ts: Timestamp) -> bool {
+        self.is_valid()
+    }
 }
 
 impl<T: SigningCredential> SigningCredential for Option<T> {

--- a/core/src/signer.rs
+++ b/core/src/signer.rs
@@ -23,6 +23,7 @@ use crate::Result;
 use crate::SignRequest;
 use crate::SignRequestDyn;
 use crate::SigningCredential;
+use crate::time::Timestamp;
 use std::any::type_name;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -81,7 +82,9 @@ impl<K: SigningCredential> Signer<K> {
         expires_in: Option<Duration>,
     ) -> Result<()> {
         let credential = self.credential.lock().expect("lock poisoned").clone();
-        let credential = if credential.is_valid() {
+        let credential = if credential.is_valid()
+            && expires_in.is_none_or(|d| credential.is_valid_at(Timestamp::now() + d))
+        {
             credential
         } else {
             let ctx = self.loader.provide_credential_dyn(&self.ctx).await?;

--- a/services/aws-v4/src/credential.rs
+++ b/services/aws-v4/src/credential.rs
@@ -47,16 +47,18 @@ impl Debug for Credential {
 
 impl SigningCredential for Credential {
     fn is_valid(&self) -> bool {
+        self.is_valid_at(Timestamp::now())
+    }
+
+    fn is_valid_at(&self, ts: Timestamp) -> bool {
         if (self.access_key_id.is_empty() || self.secret_access_key.is_empty())
             && self.session_token.is_none()
         {
             return false;
         }
+
         // Take 120s as buffer to avoid edge cases.
-        if let Some(valid) = self
-            .expires_in
-            .map(|v| v > Timestamp::now() + Duration::from_secs(120))
-        {
+        if let Some(valid) = self.expires_in.map(|v| v > ts + Duration::from_secs(120)) {
             return valid;
         }
 


### PR DESCRIPTION
When signing requests, we currently only check that the credential is *currently* valid, but on some backends (for example AWS), the signature lifetime is capped to the credential lifetime. In those situations, we need to refresh credentials instead of using the cached ones.

This is still best-effort; if the minimum expiry of the credential is less than the desired expiry of the signature, there's nothing we can do. We could change the signature of `is_valid_at` to return a potential error if the requested expiry is impossible to fulfill, up to you.

Fixes #771.