### PR TITLE
chore: prepare v0.20.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,18 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-reqsign-aliyun-oss = { version = "3.1.0", path = "services/aliyun-oss" }
-reqsign-aws-v4 = { version = "3.0.1", path = "services/aws-v4" }
-reqsign-azure-storage = { version = "3.0.1", path = "services/azure-storage" }
-reqsign-command-execute-tokio = { version = "3.0.1", path = "context/command-execute-tokio" }
-reqsign-core = { version = "3.0.1", path = "core" }
-reqsign-file-read-tokio = { version = "3.0.1", path = "context/file-read-tokio" }
-reqsign-google = { version = "3.0.1", path = "services/google" }
-reqsign-http-send-reqwest = { version = "4.0.1", path = "context/http-send-reqwest" }
-reqsign-huaweicloud-obs = { version = "3.0.1", path = "services/huaweicloud-obs" }
-reqsign-oracle = { version = "3.0.1", path = "services/oracle" }
-reqsign-tencent-cos = { version = "3.0.1", path = "services/tencent-cos" }
-reqsign-volcengine-tos = { version = "3.0.1", path = "services/volcengine-tos" }
+reqsign-aliyun-oss = { version = "3.1.1", path = "services/aliyun-oss" }
+reqsign-aws-v4 = { version = "3.0.2", path = "services/aws-v4" }
+reqsign-azure-storage = { version = "3.1.0", path = "services/azure-storage" }
+reqsign-command-execute-tokio = { version = "3.0.2", path = "context/command-execute-tokio" }
+reqsign-core = { version = "3.1.0", path = "core" }
+reqsign-file-read-tokio = { version = "3.0.2", path = "context/file-read-tokio" }
+reqsign-google = { version = "3.0.2", path = "services/google" }
+reqsign-http-send-reqwest = { version = "4.0.2", path = "context/http-send-reqwest" }
+reqsign-huaweicloud-obs = { version = "3.0.2", path = "services/huaweicloud-obs" }
+reqsign-oracle = { version = "3.0.2", path = "services/oracle" }
+reqsign-tencent-cos = { version = "3.0.2", path = "services/tencent-cos" }
+reqsign-volcengine-tos = { version = "3.0.2", path = "services/volcengine-tos" }
 
 # Crates.io dependencies
 anyhow = "1"

--- a/context/command-execute-tokio/Cargo.toml
+++ b/context/command-execute-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-command-execute-tokio"
-version = "3.0.1"
+version = "3.0.2"
 
 categories = ["asynchronous"]
 description = "Tokio-based command execution implementation for reqsign"

--- a/context/file-read-tokio/Cargo.toml
+++ b/context/file-read-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-file-read-tokio"
-version = "3.0.1"
+version = "3.0.2"
 
 categories = ["asynchronous"]
 description = "Tokio-based file reader implementation for reqsign"

--- a/context/http-send-reqwest/Cargo.toml
+++ b/context/http-send-reqwest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-http-send-reqwest"
-version = "4.0.1"
+version = "4.0.2"
 
 categories = ["asynchronous"]
 description = "Reqwest-based HTTP client implementation for reqsign."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-core"
-version = "3.0.1"
+version = "3.1.0"
 
 categories = ["command-line-utilities", "web-programming"]
 description = "Signing API requests without effort."

--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign"
-version = "0.20.1"
+version = "0.20.2"
 
 categories = ["authentication", "web-programming::http-client"]
 description = "Signing HTTP requests for AWS, Azure, Google, Huawei, Aliyun, Tencent and Oracle services"

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aliyun-oss"
-version = "3.1.0"
+version = "3.1.1"
 
 description = "Aliyun OSS signing implementation for reqsign."
 

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aws-v4"
-version = "3.0.1"
+version = "3.0.2"
 
 description = "AWS SigV4 signing implementation for reqsign."
 

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-azure-storage"
-version = "3.0.1"
+version = "3.1.0"
 
 description = "Azure Storage signing implementation for reqsign."
 

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-google"
-version = "3.0.1"
+version = "3.0.2"
 
 description = "Google Cloud Platform signing implementation for reqsign."
 

--- a/services/huaweicloud-obs/Cargo.toml
+++ b/services/huaweicloud-obs/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-huaweicloud-obs"
-version = "3.0.1"
+version = "3.0.2"
 
 description = "Huawei Cloud OBS signing implementation for reqsign."
 

--- a/services/oracle/Cargo.toml
+++ b/services/oracle/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-oracle"
-version = "3.0.1"
+version = "3.0.2"
 
 description = "Oracle Cloud signing implementation for reqsign."
 

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-tencent-cos"
-version = "3.0.1"
+version = "3.0.2"
 
 description = "Tencent Cloud COS signing implementation for reqsign."
 

--- a/services/volcengine-tos/Cargo.toml
+++ b/services/volcengine-tos/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-volcengine-tos"
-version = "3.0.1"
+version = "3.0.2"
 
 description = "Volcengine TOS signing implementation for reqsign."
 


### PR DESCRIPTION
## Summary

Prepare Apache OpenDAL reqsign v0.20.2 release.

Version bumps:

- `reqsign`: 0.20.1 -> 0.20.2
- `reqsign-core`: 3.0.1 -> 3.1.0
- `reqsign-azure-storage`: 3.0.1 -> 3.1.0
- `reqsign-aliyun-oss`: 3.1.0 -> 3.1.1
- Other 3.x workspace crates: 3.0.1 -> 3.0.2
- `reqsign-http-send-reqwest`: 4.0.1 -> 4.0.2

Rationale:

- `reqsign-core` adds the public `SigningCredential::is_valid_at` API.
- `reqsign-azure-storage` adds public credential provider setters.
- Other workspace crates are patch bumped for the workspace release.

## Verification

- `cargo check --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`
- `cargo test --doc --all-features --workspace`
- `cargo publish --workspace --dry-run --allow-dirty`

Note: `wasm32-unknown-unknown` was not installed locally, so WASM target checks are left to CI.
