### PR TITLE
fix(google): allow signing during token refresh window

### DIFF
--- a/services/aws-v4/src/sign_request.rs
+++ b/services/aws-v4/src/sign_request.rs
@@ -553,7 +553,7 @@ mod tests {
         fn format_query(req: &Request<&str>) -> Vec<String> {
             let query = req.uri().query().unwrap_or_default();
             let mut query = form_urlencoded::parse(query.as_bytes())
-                .map(|(k, v)| format!("{}={}", &k, &v))
+                .map(|(k, v)| format!("{}={}", k, v))
                 .collect::<Vec<_>>();
             query.sort();
             query

--- a/services/google/src/credential.rs
+++ b/services/google/src/credential.rs
@@ -19,6 +19,9 @@ use reqsign_core::{Result, SigningCredential as KeyTrait, time::Timestamp, utils
 use std::fmt::{self, Debug};
 use std::time::Duration;
 
+const TOKEN_REFRESH_BUFFER: Duration = Duration::from_secs(120);
+const TOKEN_SIGNING_BUFFER: Duration = Duration::from_secs(10);
+
 /// ServiceAccount holds the client email and private key for service account authentication.
 #[derive(Clone, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -236,18 +239,25 @@ impl Debug for Token {
     }
 }
 
+impl Token {
+    /// Returns whether the token has enough lifetime left to sign a request.
+    pub(crate) fn can_sign_request(&self) -> bool {
+        self.is_valid_at(Timestamp::now() + TOKEN_SIGNING_BUFFER)
+    }
+}
+
 impl KeyTrait for Token {
     fn is_valid(&self) -> bool {
+        self.is_valid_at(Timestamp::now() + TOKEN_REFRESH_BUFFER)
+    }
+
+    fn is_valid_at(&self, timestamp: Timestamp) -> bool {
         if self.access_token.is_empty() {
             return false;
         }
 
         match self.expires_at {
-            Some(expires_at) => {
-                // Consider token invalid if it expires within 2 minutes
-                let buffer = Duration::from_secs(120);
-                Timestamp::now() < expires_at - buffer
-            }
+            Some(expires_at) => timestamp < expires_at,
             None => true, // No expiration means always valid
         }
     }
@@ -384,10 +394,16 @@ mod tests {
         // Token that expires within 2 minutes
         token.expires_at = Some(Timestamp::now() + Duration::from_secs(30));
         assert!(!token.is_valid());
+        assert!(token.can_sign_request());
+
+        // Token that expires too soon to safely sign a request
+        token.expires_at = Some(Timestamp::now() + Duration::from_secs(5));
+        assert!(!token.can_sign_request());
 
         // Expired token
         token.expires_at = Some(Timestamp::now() - Duration::from_secs(3600));
         assert!(!token.is_valid());
+        assert!(!token.can_sign_request());
 
         // Empty access token
         token.access_token = String::new();

--- a/services/google/src/sign_request.rs
+++ b/services/google/src/sign_request.rs
@@ -27,8 +27,7 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use reqsign_core::{
-    Context, Result, SignRequest, SigningCredential, SigningMethod, SigningRequest,
-    hash::hex_sha256, time::*,
+    Context, Result, SignRequest, SigningMethod, SigningRequest, hash::hex_sha256, time::*,
 };
 
 use crate::constants::{DEFAULT_SCOPE, GOOG_QUERY_ENCODE_SET, GOOG_URI_ENCODE_SET, GOOGLE_SCOPE};
@@ -391,7 +390,7 @@ impl SignRequest for RequestSigner {
                 } else if let (Some(token), Some(signer_email)) =
                     (cred.token.as_ref(), self.signer_email.as_deref())
                 {
-                    if !token.is_valid() {
+                    if !token.can_sign_request() {
                         return Err(reqsign_core::Error::credential_invalid(
                             "token required for iamcredentials signBlob query signing",
                         ));
@@ -413,9 +412,10 @@ impl SignRequest for RequestSigner {
             }
             // Header authentication - prefer valid token, otherwise exchange from SA
             None => {
-                // Check if we have a valid token
+                // Tokens inside the refresh window are still usable for the current request. The
+                // credential cache will reload them before the next request.
                 if let Some(token) = &cred.token {
-                    if token.is_valid() {
+                    if token.can_sign_request() {
                         self.build_token_auth(req, token)?
                     } else if let Some(sa) = &cred.service_account {
                         // Token expired, but we have SA, exchange for new token
@@ -702,6 +702,38 @@ mod tests {
             .expect("payload must be recorded");
 
         assert_eq!(recorded_payload_b64, expected_payload_b64);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_header_auth_with_token_inside_refresh_window() -> Result<()> {
+        let ctx = Context::new();
+        let signer = RequestSigner::new("storage");
+        let cred = Credential::with_token(Token {
+            access_token: "test-access-token".to_string(),
+            expires_at: Some(Timestamp::now() + Duration::from_secs(30)),
+        });
+        assert!(!cred.has_valid_token());
+
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://storage.googleapis.com/test-bucket/test-object")
+            .body(Bytes::new())
+            .expect("request must build");
+        let (mut parts, _body) = req.into_parts();
+
+        signer
+            .sign_request(&ctx, &mut parts, Some(&cred), None)
+            .await?;
+
+        assert_eq!(
+            parts
+                .headers
+                .get(header::AUTHORIZATION)
+                .expect("authorization must exist"),
+            "Bearer test-access-token"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- keep the two-minute Google access-token refresh buffer used by the credential cache
- allow the request signer to use a still-live token inside that refresh window, with ten seconds of transport headroom
- add regression coverage for header authentication with a token that is refreshable but not expired

## Background

On GKE, the metadata service can return the same access token near its hourly expiration. The credential cache correctly asks for a refresh two minutes early, but the request signer then applies that refresh threshold again and rejects the returned token. Workload Identity has no service-account private key fallback, so GCS writes fail with `token expired and no service account available` even though the access token is still valid.

This change separates cache refresh eligibility from current-request signing eligibility. The cache will retry loading credentials on the next request, while the current request can proceed with the still-live token.

## Example of errors seen in a Quickwit production deployment

A [Quickwit](https://github.com/quickwit-oss/quickwit) user shared with us a log error observed every hour on his indexers deployed on GKE:

```
WARN index-doc-batches{index_id=datadog source_id=_ingest-source pipeline_uid=01KX4YFDQ2J5KG6YMW08G1RZXR workbench_id=01KX6HVMH1WG2HW84KVFQPQ0YF}:uploader: quickwit_indexing::actors::uploader: Failed to upload split. Killing! cause=failed uploading key 01KX6HVMH57XB2NXESJAGMRP8C.split in bucket gs://datadog-cloudprem/indexes/datadog
Caused by:
    0: storage error(kind=Io, source=Unexpected (permanent) at write, context: { called: reqsign::Sign, service: gcs, path: 01KX6HVMH57XB2NXESJAGMRP8C.split, written: 15488228 } => signing http request, source: token expired and no service account available)
    1: Unexpected (permanent) at write, context: { called: reqsign::Sign, service: gcs, path: 01KX6HVMH57XB2NXESJAGMRP8C.split, written: 15488228 } => signing http request, source: token expired and no service account available
    2: token expired and no service account available split_id="01KX6HVMH57XB2NXESJAGMRP8C"
``` 

The proposed PR should fix this issue.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`
- `cargo doc -p reqsign-google --all-features --no-deps`
- `cargo test -p reqsign-aws-v4 --lib`

The workspace-wide Clippy run also checked the Google crate, but currently stops on an unrelated existing `useless_borrows_in_formatting` lint in `services/aws-v4/src/sign_request.rs` under Rust 1.97.