### PR TITLE
chore: upgrade base64 and p256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ reqsign-volcengine-tos = { version = "3.0.3", path = "services/volcengine-tos" }
 
 # Crates.io dependencies
 anyhow = "1"
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 bytes = "1"
 criterion = { version = "0.8.1", features = ["async_tokio", "html_reports"] }
 dotenvy = "0.15"
@@ -58,7 +58,7 @@ jiff = "0.2"
 log = "0.4"
 pem = "3.0"
 percent-encoding = "2"
-p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.14.0", default-features = false, features = ["ecdsa"] }
 pretty_assertions = "1.3"
 quick-xml = { version = "0.41.0", features = ["serialize"] }
 reqwest = { version = "0.13.1", default-features = false }

--- a/services/aws-v4a/src/sign_request.rs
+++ b/services/aws-v4a/src/sign_request.rs
@@ -365,7 +365,7 @@ mod tests {
     #[test]
     fn signing_key_matches_aws_public_key_vector() -> AnyResult<()> {
         let signing_key = generate_signing_key(ACCESS_KEY_ID, SECRET_ACCESS_KEY)?;
-        let public_key = signing_key.verifying_key().to_encoded_point(false);
+        let public_key = signing_key.verifying_key().to_sec1_point(false);
 
         assert_eq!(
             hex::encode(public_key.x().expect("uncompressed key has x")),


### PR DESCRIPTION
`base64` 0.23 and `p256` 0.14 are the latest stable release lines and keep reqsign aligned with their upstream encoding and cryptography stacks.

`base64` 0.23 enables unsafe SIMD by default, so this keeps only the existing `std` behavior. `p256` 0.14 renames encoded-point conversion, requiring the corresponding SigV4a public-key vector test update.
