### PR TITLE
build: use Cargo resolver 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@
 
 [workspace]
 members = ["core", "context/*", "services/*", "reqsign"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 edition = "2024"


### PR DESCRIPTION
Align the virtual workspace resolver with Rust 2024 edition defaults.

This enables rust-version-aware dependency fallback for the workspace MSRV.