### PR TITLE
feat(aws): add S3 Express CreateSession granter

### DIFF
--- a/services/aws-v4/src/lib.rs
+++ b/services/aws-v4/src/lib.rs
@@ -154,7 +154,10 @@
 mod sign_request;
 pub use sign_request::RequestSigner;
 mod provide_credential;
-pub use provide_credential::S3ExpressSessionProvider;
+pub use provide_credential::{
+    S3ExpressSessionConfig, S3ExpressSessionGrant, S3ExpressSessionGranter, S3ExpressSessionMode,
+    S3ExpressSessionPartition, S3ExpressSessionProvider,
+};
 pub use reqsign_aws_core::constants;
 pub use reqsign_aws_core::{
     AssumeRoleCredentialProvider, AssumeRoleWithWebIdentityCredentialProvider,

--- a/services/aws-v4/src/provide_credential/mod.rs
+++ b/services/aws-v4/src/provide_credential/mod.rs
@@ -16,4 +16,7 @@
 // under the License.
 
 mod s3_express_session;
-pub use s3_express_session::S3ExpressSessionProvider;
+pub use s3_express_session::{
+    S3ExpressSessionConfig, S3ExpressSessionGrant, S3ExpressSessionGranter, S3ExpressSessionMode,
+    S3ExpressSessionPartition, S3ExpressSessionProvider,
+};

--- a/services/aws-v4/src/provide_credential/s3_express_session.rs
+++ b/services/aws-v4/src/provide_credential/s3_express_session.rs
@@ -17,53 +17,553 @@
 
 use crate::Credential;
 use bytes::Bytes;
-use http::{Method, Request, header};
-use log::debug;
-use reqsign_core::{Context, Error, ProvideCredential, ProvideCredentialDyn, Result, SignRequest};
+use http::{HeaderValue, Method, Request, StatusCode, header};
+use reqsign_core::time::Timestamp;
+use reqsign_core::{
+    Context, Error, GrantCredential, ProvideCredential, ProvideCredentialDyn, Result, SignRequest,
+    SigningCredential,
+};
 use serde::Deserialize;
+use std::fmt::{Debug, Formatter};
+use std::str::FromStr;
+use std::time::Duration;
 
-/// S3 Express One Zone session provider that creates session credentials.
+const CREATE_SESSION_OPERATION_HEADROOM: Duration = Duration::from_secs(10);
+
+/// The permission mode of an S3 Express directory bucket session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum S3ExpressSessionMode {
+    /// Allows `GetObject`, `HeadObject`, `ListObjectsV2`,
+    /// `GetObjectAttributes`, `ListParts`, and `ListMultipartUploads`.
+    ReadOnly,
+    /// Allows all Zonal endpoint operations that use session credentials.
+    ReadWrite,
+}
+
+impl S3ExpressSessionMode {
+    /// Return the AWS wire value for this mode.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "ReadOnly",
+            Self::ReadWrite => "ReadWrite",
+        }
+    }
+}
+
+impl FromStr for S3ExpressSessionMode {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "ReadOnly" => Ok(Self::ReadOnly),
+            "ReadWrite" => Ok(Self::ReadWrite),
+            _ => Err(Error::config_invalid(
+                "S3 Express session mode must be ReadOnly or ReadWrite",
+            )),
+        }
+    }
+}
+
+/// An AWS partition supported by the S3 Express session endpoint model.
 ///
-/// This provider implements the CreateSession API for S3 Express One Zone buckets,
-/// which provides low-latency access through temporary session-based credentials.
+/// The partition is bound into [`S3ExpressSessionConfig`] so its DNS suffix
+/// cannot be inferred incorrectly from a directory bucket at request time.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum S3ExpressSessionPartition {
+    /// The standard `aws` partition.
+    Aws,
+    /// The `aws-cn` partition.
+    AwsCn,
+}
+
+impl S3ExpressSessionPartition {
+    /// Resolve a supported S3 Express session partition from an AWS Region.
+    ///
+    /// Regions in unsupported partitions are rejected before any credential or
+    /// HTTP I/O.
+    pub fn from_region(region: &str) -> Result<Self> {
+        region_zone_prefix(region)?;
+        let segments = region.split('-').collect::<Vec<_>>();
+        match segments.as_slice() {
+            ["cn", _, _] => Ok(Self::AwsCn),
+            [prefix, _, _]
+                if matches!(
+                    *prefix,
+                    "us" | "eu" | "ap" | "sa" | "ca" | "me" | "af" | "il" | "mx"
+                ) =>
+            {
+                Ok(Self::Aws)
+            }
+            _ => Err(Error::config_invalid(
+                "AWS Region belongs to an unsupported partition for S3 Express sessions",
+            )),
+        }
+    }
+
+    /// Return the AWS partition identifier.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Aws => "aws",
+            Self::AwsCn => "aws-cn",
+        }
+    }
+
+    /// Return the partition DNS suffix used by S3 Express endpoints.
+    pub fn dns_suffix(self) -> &'static str {
+        match self {
+            Self::Aws => "amazonaws.com",
+            Self::AwsCn => "amazonaws.com.cn",
+        }
+    }
+}
+
+impl FromStr for S3ExpressSessionPartition {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "aws" => Ok(Self::Aws),
+            "aws-cn" => Ok(Self::AwsCn),
+            _ => Err(Error::config_invalid(
+                "S3 Express session partition must be aws or aws-cn",
+            )),
+        }
+    }
+}
+
+/// A complete S3 Express `CreateSession` authorization grant.
 ///
-/// # Important
+/// The source AWS principal must have `s3express:CreateSession` permission for
+/// the directory bucket bound by [`S3ExpressSessionConfig`]. A bucket or
+/// identity policy can use the `s3express:SessionMode` condition key to limit
+/// which mode that principal may grant.
 ///
-/// - The session token returned by this provider should be used with the
-///   `x-amz-s3session-token` header instead of the standard `x-amz-security-token`
-///   header when making requests to S3 Express One Zone buckets.
-/// - This provider does not cache sessions internally. The upper layer (e.g., Signer)
-///   handles credential caching and will request new sessions when they expire.
+/// This grant does not override the directory bucket's encryption settings.
+/// CreateSession therefore uses the bucket default, matching the compatibility
+/// provider and AWS SDK guidance.
+#[derive(Clone, Eq, PartialEq)]
+pub struct S3ExpressSessionGrant {
+    mode: S3ExpressSessionMode,
+}
+
+impl Debug for S3ExpressSessionGrant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3ExpressSessionGrant")
+            .finish_non_exhaustive()
+    }
+}
+
+impl S3ExpressSessionGrant {
+    /// Bind an explicit session mode.
+    pub fn new(mode: S3ExpressSessionMode) -> Self {
+        Self { mode }
+    }
+
+    /// Return the bound session mode.
+    pub fn mode(&self) -> S3ExpressSessionMode {
+        self.mode
+    }
+}
+
+/// Validated, stable S3 Express directory bucket configuration.
+///
+/// `bucket`, `zone_id`, `region`, and `partition` are bound together so the
+/// Zonal endpoint can be constructed once and cannot drift between grants.
+#[derive(Clone, Eq, PartialEq)]
+pub struct S3ExpressSessionConfig {
+    bucket: String,
+    zone_id: String,
+    region: String,
+    partition: S3ExpressSessionPartition,
+    endpoint: String,
+}
+
+impl Debug for S3ExpressSessionConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3ExpressSessionConfig")
+            .finish_non_exhaustive()
+    }
+}
+
+impl S3ExpressSessionConfig {
+    /// Create and validate a directory bucket configuration.
+    ///
+    /// `bucket` must include the exact `--{zone_id}--x-s3` suffix. `zone_id`
+    /// must belong to `region` according to the AWS Zone ID prefix convention,
+    /// and `region` must belong to `partition`.
+    pub fn new(
+        bucket: impl Into<String>,
+        zone_id: impl Into<String>,
+        region: impl Into<String>,
+        partition: S3ExpressSessionPartition,
+    ) -> Result<Self> {
+        let bucket = bucket.into();
+        let zone_id = zone_id.into();
+        let region = region.into();
+
+        validate_directory_bucket_name(&bucket)?;
+        validate_zone_id(&zone_id)?;
+        let expected_zone_id = zone_id_from_bucket(&bucket)?;
+        if expected_zone_id != zone_id {
+            return Err(Error::config_invalid(
+                "S3 Express directory bucket suffix does not match the configured Zone ID",
+            ));
+        }
+
+        let expected_partition = S3ExpressSessionPartition::from_region(&region)?;
+        if expected_partition != partition {
+            return Err(Error::config_invalid(
+                "AWS Region does not belong to the configured S3 Express session partition",
+            ));
+        }
+
+        let zone_prefix = region_zone_prefix(&region)?;
+        if zone_id.split('-').next() != Some(zone_prefix.as_str()) {
+            return Err(Error::config_invalid(
+                "S3 Express Zone ID does not match the configured AWS Region",
+            ));
+        }
+
+        let endpoint = format!(
+            "https://{bucket}.s3express-{zone_id}.{region}.{}",
+            partition.dns_suffix()
+        );
+        Ok(Self {
+            bucket,
+            zone_id,
+            region,
+            partition,
+            endpoint,
+        })
+    }
+
+    /// Return the directory bucket name.
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// Return the AWS Zone ID.
+    pub fn zone_id(&self) -> &str {
+        &self.zone_id
+    }
+
+    /// Return the AWS Region.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// Return the AWS partition.
+    pub fn partition(&self) -> S3ExpressSessionPartition {
+        self.partition
+    }
+
+    /// Return the HTTPS Zonal endpoint.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+/// Grants expiration-aware AWS credentials for one S3 Express directory bucket.
+///
+/// The source credential authorizes `s3express:CreateSession` and is used only
+/// to sign the issuance request. The output contains only the independently
+/// usable access key, secret access key, S3 session token, and exact expiration
+/// returned by S3. Every call performs a new `CreateSession`; granted outputs
+/// are never cached.
+///
+/// S3 fixes the session lifetime at five minutes and does not expose a lifetime
+/// request parameter. Call [`reqsign_core::Granter::grant`] with `None`.
 ///
 /// # Example
 ///
 /// ```no_run
-/// use reqsign_aws_v4::{S3ExpressSessionProvider, DefaultCredentialProvider};
-/// use reqsign_core::ProvideCredential;
+/// use reqsign_aws_v4::{
+///     DefaultCredentialProvider, S3ExpressSessionConfig, S3ExpressSessionGrant,
+///     S3ExpressSessionGranter, S3ExpressSessionMode, S3ExpressSessionPartition,
+/// };
+/// use reqsign_core::{Context, Granter};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let provider = S3ExpressSessionProvider::new(
+/// let config = S3ExpressSessionConfig::new(
 ///     "my-bucket--usw2-az1--x-s3",
+///     "usw2-az1",
+///     "us-west-2",
+///     S3ExpressSessionPartition::Aws,
+/// )?;
+/// let grant = S3ExpressSessionGrant::new(S3ExpressSessionMode::ReadOnly);
+/// let granter = Granter::new(
+///     Context::new(),
 ///     DefaultCredentialProvider::new(),
+///     S3ExpressSessionGranter::new(config, grant),
 /// );
 ///
-/// // Each call to provide_credential creates a new session
+/// let credential = granter.grant(None).await?;
+/// # let _ = credential;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive(Clone)]
+pub struct S3ExpressSessionGranter {
+    config: S3ExpressSessionConfig,
+    grant: S3ExpressSessionGrant,
+    #[cfg(test)]
+    time: Option<Timestamp>,
+    #[cfg(test)]
+    time_after_request: Option<Timestamp>,
+}
+
+impl Debug for S3ExpressSessionGranter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3ExpressSessionGranter")
+            .finish_non_exhaustive()
+    }
+}
+
+impl S3ExpressSessionGranter {
+    /// Create a granter with stable bucket configuration and a complete grant.
+    pub fn new(config: S3ExpressSessionConfig, grant: S3ExpressSessionGrant) -> Self {
+        Self {
+            config,
+            grant,
+            #[cfg(test)]
+            time: None,
+            #[cfg(test)]
+            time_after_request: None,
+        }
+    }
+
+    /// Replace the bound grant while retaining the stable bucket configuration.
+    pub fn with_grant(mut self, grant: S3ExpressSessionGrant) -> Self {
+        self.grant = grant;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_time(mut self, time: Timestamp) -> Self {
+        self.time = Some(time);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_time_after_request(mut self, time: Timestamp) -> Self {
+        self.time_after_request = Some(time);
+        self
+    }
+
+    fn now(&self) -> Timestamp {
+        #[cfg(test)]
+        if let Some(time) = self.time {
+            return time;
+        }
+        Timestamp::now()
+    }
+
+    fn now_after_request(&self) -> Timestamp {
+        #[cfg(test)]
+        if let Some(time) = self.time_after_request {
+            return time;
+        }
+        #[cfg(test)]
+        if let Some(time) = self.time {
+            return time;
+        }
+        Timestamp::now()
+    }
+
+    fn validate_request(
+        &self,
+        source: &Credential,
+        expires_in: Option<Duration>,
+    ) -> Result<Timestamp> {
+        if expires_in.is_some() {
+            return Err(Error::request_invalid(
+                "S3 Express CreateSession does not support a caller-selected lifetime",
+            ));
+        }
+        if source.session_token.as_ref().is_some_and(String::is_empty) {
+            return Err(Error::credential_invalid(
+                "AWS source credential contains an empty session token",
+            ));
+        }
+
+        let required_valid_until = self.now() + CREATE_SESSION_OPERATION_HEADROOM;
+        if !source.is_valid_at(required_valid_until) {
+            return Err(Error::credential_invalid(
+                "AWS source credential is not usable through the CreateSession request deadline",
+            ));
+        }
+        Ok(required_valid_until)
+    }
+
+    async fn create_session(&self, ctx: &Context, source: &Credential) -> Result<Credential> {
+        let authority = self
+            .config
+            .endpoint
+            .strip_prefix("https://")
+            .expect("validated endpoint must use HTTPS");
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(format!("{}/?session", self.config.endpoint))
+            .header(header::HOST, authority)
+            .header("x-amz-content-sha256", crate::EMPTY_STRING_SHA256)
+            .header("x-amz-create-session-mode", self.grant.mode.as_str())
+            .body(Bytes::new())
+            .map_err(|e| {
+                Error::request_invalid("failed to build S3 Express CreateSession request")
+                    .with_source(e)
+            })?;
+
+        let (mut parts, body) = request.into_parts();
+        let mut signing_source = source.clone();
+        if let Some(token) = signing_source.session_token.take() {
+            let mut value = HeaderValue::from_str(&token).map_err(|_| {
+                Error::credential_invalid(
+                    "AWS source credential session token is not a valid HTTP header value",
+                )
+            })?;
+            value.set_sensitive(true);
+            parts.headers.insert("x-amz-security-token", value);
+        }
+
+        let signer = crate::RequestSigner::new("s3express", &self.config.region);
+        #[cfg(test)]
+        let signer = if let Some(time) = self.time {
+            signer.with_time(time)
+        } else {
+            signer
+        };
+        signer
+            .sign_request(ctx, &mut parts, Some(&signing_source), None)
+            .await?;
+
+        let response = ctx.http_send(Request::from_parts(parts, body)).await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(create_session_status_error(status));
+        }
+
+        parse_create_session_response(response.body(), self.now_after_request())
+    }
+}
+
+impl GrantCredential for S3ExpressSessionGranter {
+    type Credential = Credential;
+
+    fn required_valid_until(
+        &self,
+        _credential: &Self::Credential,
+        _expires_in: Option<Duration>,
+    ) -> Timestamp {
+        self.now() + CREATE_SESSION_OPERATION_HEADROOM
+    }
+
+    async fn grant_credential(
+        &self,
+        ctx: &Context,
+        credential: &Self::Credential,
+        expires_in: Option<Duration>,
+    ) -> Result<Self::Credential> {
+        self.validate_request(credential, expires_in)?;
+        self.create_session(ctx, credential).await
+    }
+}
+
+/// S3 Express fixed-flow credential provider.
+///
+/// This compatibility API loads its source through [`ProvideCredential`] and
+/// creates a `ReadWrite` session on every call. New explicit credential-vending
+/// flows should use [`S3ExpressSessionGranter`] through
+/// [`reqsign_core::Granter`].
 pub struct S3ExpressSessionProvider {
     bucket: String,
+    region: Option<String>,
     base_provider: Box<dyn ProvideCredentialDyn<Credential = Credential>>,
 }
 
-#[derive(Debug, Deserialize)]
+impl Debug for S3ExpressSessionProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3ExpressSessionProvider")
+            .finish_non_exhaustive()
+    }
+}
+
+impl S3ExpressSessionProvider {
+    /// Create a fixed `ReadWrite` session provider for a directory bucket.
+    ///
+    /// The legacy constructor infers the Region from well-known AWS Zone ID
+    /// prefixes. Use [`S3ExpressSessionProvider::with_region`] when the Zone is
+    /// new or belongs to a Local Zone that the compatibility inference does not
+    /// recognize.
+    pub fn new(
+        bucket: impl Into<String>,
+        provider: impl ProvideCredential<Credential = Credential> + 'static,
+    ) -> Self {
+        Self {
+            bucket: bucket.into(),
+            region: None,
+            base_provider: Box::new(provider),
+        }
+    }
+
+    /// Bind the AWS Region instead of using compatibility inference.
+    pub fn with_region(mut self, region: impl Into<String>) -> Self {
+        self.region = Some(region.into());
+        self
+    }
+
+    fn operation(&self) -> Result<S3ExpressSessionGranter> {
+        let zone_id = zone_id_from_bucket(&self.bucket)?;
+        let region = match &self.region {
+            Some(region) => region.clone(),
+            None => infer_region_from_zone_id(&zone_id).ok_or_else(|| {
+                Error::config_invalid(
+                    "cannot infer AWS Region from S3 Express Zone ID; use with_region",
+                )
+            })?,
+        };
+        let partition = S3ExpressSessionPartition::from_region(&region)?;
+        let config = S3ExpressSessionConfig::new(&self.bucket, zone_id, region, partition)?;
+        Ok(S3ExpressSessionGranter::new(
+            config,
+            S3ExpressSessionGrant::new(S3ExpressSessionMode::ReadWrite),
+        ))
+    }
+}
+
+impl ProvideCredential for S3ExpressSessionProvider {
+    type Credential = Credential;
+
+    async fn provide_credential(&self, ctx: &Context) -> Result<Option<Self::Credential>> {
+        // Validate fixed configuration before the source provider can perform I/O.
+        let operation = self.operation()?;
+        let source = self
+            .base_provider
+            .provide_credential_dyn(ctx)
+            .await?
+            .ok_or_else(|| {
+                Error::credential_invalid(
+                    "S3 Express CreateSession requires an AWS source credential",
+                )
+            })?;
+        Ok(Some(operation.grant_credential(ctx, &source, None).await?))
+    }
+}
+
+#[derive(Deserialize)]
 #[serde(rename = "CreateSessionResult", rename_all = "PascalCase")]
 struct CreateSessionResponse {
     credentials: SessionCredentials,
 }
 
-#[derive(Debug, Deserialize)]
+impl Debug for CreateSessionResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CreateSessionResponse")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct SessionCredentials {
     session_token: String,
@@ -72,205 +572,987 @@ struct SessionCredentials {
     expiration: String,
 }
 
-impl S3ExpressSessionProvider {
-    /// Create a new S3 Express session provider for a specific bucket.
-    ///
-    /// # Arguments
-    ///
-    /// * `bucket` - The S3 Express One Zone bucket name (e.g., "my-bucket--usw2-az1--x-s3")
-    /// * `provider` - The base credential provider to use for CreateSession API calls
-    pub fn new(
-        bucket: impl Into<String>,
-        provider: impl ProvideCredential<Credential = Credential> + 'static,
-    ) -> Self {
-        Self {
-            bucket: bucket.into(),
-            base_provider: Box::new(provider),
-        }
-    }
-
-    /// Create a new session for the bucket using the CreateSession API.
-    async fn create_session(&self, ctx: &Context, base_cred: &Credential) -> Result<Credential> {
-        debug!(
-            "Creating new S3 Express session for bucket: {}",
-            self.bucket
-        );
-
-        // Extract region from bucket name (format: name--azid--x-s3)
-        let parts: Vec<&str> = self.bucket.split("--").collect();
-        if parts.len() != 3 || !parts[2].ends_with("x-s3") {
-            return Err(Error::unexpected(format!(
-                "Invalid S3 Express bucket name format: {}",
-                self.bucket
-            )));
-        }
-
-        // Extract region from AZ ID (e.g., "usw2-az1" -> "us-west-2")
-        let az_id = parts[1];
-        let region = self.parse_region_from_az_id(az_id)?;
-
-        // Build CreateSession request
-        let url = format!(
-            "https://{}.s3express-{}.amazonaws.com/?session",
-            self.bucket, az_id
-        );
-        let req = Request::builder()
-            .method(Method::GET)
-            .uri(&url)
-            .header(
-                header::HOST,
-                format!("{}.s3express-{}.amazonaws.com", self.bucket, az_id),
-            )
-            .header("x-amz-content-sha256", crate::EMPTY_STRING_SHA256)
-            .header("x-amz-create-session-mode", "ReadWrite")
-            .body(Bytes::new())
-            .map_err(|e| Error::unexpected(format!("Failed to build request: {e}")))?;
-
-        // Sign the request using base credentials
-        let (mut parts, body) = req.into_parts();
-        let signer = crate::RequestSigner::new("s3express", &region);
-        signer
-            .sign_request(ctx, &mut parts, Some(base_cred), None)
-            .await?;
-
-        // Send the request
-        let req = Request::from_parts(parts, body);
-        let resp = ctx.http_send(req).await?;
-
-        // Check response status
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.into_body();
-            let error_msg = String::from_utf8_lossy(&body);
-            return Err(Error::unexpected(format!(
-                "CreateSession failed with status {status}: {error_msg}"
-            )));
-        }
-
-        // Parse XML response
-        let body = resp.into_body();
-        let body_str = String::from_utf8_lossy(&body);
-        debug!("CreateSession response body: {body_str}");
-
-        let create_session_resp: CreateSessionResponse = quick_xml::de::from_str(&body_str)
-            .map_err(|e| {
-                Error::unexpected(format!("Failed to parse CreateSession XML response: {e}"))
-            })?;
-
-        // Parse expiration time from ISO8601 format
-        let expiration = create_session_resp
-            .credentials
-            .expiration
-            .parse()
-            .map_err(|e| {
-                Error::unexpected(format!(
-                    "failed to parse expiration time '{}': {e}",
-                    create_session_resp.credentials.expiration
-                ))
-            })?;
-
-        // Convert to Credential with expiration time
-        let creds = create_session_resp.credentials;
-        Ok(Credential {
-            access_key_id: creds.access_key_id,
-            secret_access_key: creds.secret_access_key,
-            session_token: Some(creds.session_token),
-            expires_in: Some(expiration),
-        })
-    }
-
-    /// Parse region from AZ ID (e.g., "usw2-az1" -> "us-west-2")
-    fn parse_region_from_az_id(&self, az_id: &str) -> Result<String> {
-        // Common region mappings
-        let region = match az_id {
-            az if az.starts_with("use1-") => "us-east-1",
-            az if az.starts_with("use2-") => "us-east-2",
-            az if az.starts_with("usw1-") => "us-west-1",
-            az if az.starts_with("usw2-") => "us-west-2",
-            az if az.starts_with("euw1-") => "eu-west-1",
-            az if az.starts_with("euc1-") => "eu-central-1",
-            az if az.starts_with("apne1-") => "ap-northeast-1",
-            az if az.starts_with("apse1-") => "ap-southeast-1",
-            az if az.starts_with("apse2-") => "ap-southeast-2",
-            _ => return Err(Error::unexpected(format!("Unknown AZ ID format: {az_id}"))),
-        };
-        Ok(region.to_string())
+impl Debug for SessionCredentials {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionCredentials").finish_non_exhaustive()
     }
 }
-impl ProvideCredential for S3ExpressSessionProvider {
-    type Credential = Credential;
 
-    async fn provide_credential(&self, ctx: &Context) -> Result<Option<Self::Credential>> {
-        debug!("Creating S3 Express session for bucket: {}", self.bucket);
+fn parse_create_session_response(body: &[u8], validated_at: Timestamp) -> Result<Credential> {
+    let body = std::str::from_utf8(body)
+        .map_err(|_| Error::unexpected("S3 Express CreateSession response is not valid UTF-8"))?;
+    let response: CreateSessionResponse = quick_xml::de::from_str(body)
+        .map_err(|_| Error::unexpected("failed to parse S3 Express CreateSession response"))?;
+    let credentials = response.credentials;
 
-        // Get base credentials - required for S3 Express
-        let base_cred = self.base_provider.provide_credential_dyn(ctx).await?
-            .ok_or_else(|| {
-                Error::unexpected(
-                    "No base credentials found. S3 Express requires valid AWS credentials to create sessions"
-                )
-            })?;
-
-        // Create new session
-        let session_cred = self.create_session(ctx, &base_cred).await?;
-
-        Ok(Some(session_cred))
+    if credentials.access_key_id.is_empty()
+        || credentials.secret_access_key.is_empty()
+        || credentials.session_token.is_empty()
+    {
+        return Err(Error::credential_invalid(
+            "S3 Express CreateSession returned incomplete credentials",
+        ));
     }
+    let expiration = credentials.expiration.parse().map_err(|_| {
+        Error::credential_invalid(
+            "S3 Express CreateSession returned an invalid credential expiration",
+        )
+    })?;
+    let credential = Credential {
+        access_key_id: credentials.access_key_id,
+        secret_access_key: credentials.secret_access_key,
+        session_token: Some(credentials.session_token),
+        expires_in: Some(expiration),
+    };
+    if !credential.is_valid_at(validated_at) {
+        return Err(Error::credential_invalid(
+            "S3 Express CreateSession returned credentials that are no longer usable",
+        ));
+    }
+    Ok(credential)
+}
+
+fn create_session_status_error(status: StatusCode) -> Error {
+    let error = match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Error::permission_denied(
+            "S3 Express CreateSession was not authorized for the source AWS credential",
+        ),
+        StatusCode::TOO_MANY_REQUESTS => {
+            Error::rate_limited("S3 Express CreateSession was rate limited")
+        }
+        status if status.is_server_error() => {
+            Error::unexpected("S3 Express CreateSession service failed").set_retryable(true)
+        }
+        _ => Error::unexpected("S3 Express CreateSession request failed"),
+    };
+    error.with_context(format!("status: {}", status.as_u16()))
+}
+
+fn validate_directory_bucket_name(bucket: &str) -> Result<()> {
+    if !(3..=63).contains(&bucket.len())
+        || !bucket
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        || !bucket
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        || !bucket
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
+    {
+        return Err(Error::config_invalid(
+            "invalid S3 Express directory bucket name",
+        ));
+    }
+    if ["xn--", "sthree-", "amzn-s3-demo-"]
+        .iter()
+        .any(|prefix| bucket.starts_with(prefix))
+    {
+        return Err(Error::config_invalid(
+            "S3 Express directory bucket uses a reserved prefix",
+        ));
+    }
+    zone_id_from_bucket(bucket)?;
+    Ok(())
+}
+
+fn zone_id_from_bucket(bucket: &str) -> Result<String> {
+    let without_suffix = bucket.strip_suffix("--x-s3").ok_or_else(|| {
+        Error::config_invalid("S3 Express directory bucket must end with --{zone-id}--x-s3")
+    })?;
+    let (base, zone_id) = without_suffix.rsplit_once("--").ok_or_else(|| {
+        Error::config_invalid("S3 Express directory bucket must include a base name and Zone ID")
+    })?;
+    if base.is_empty() || zone_id.is_empty() {
+        return Err(Error::config_invalid(
+            "S3 Express directory bucket must include a base name and Zone ID",
+        ));
+    }
+    Ok(zone_id.to_string())
+}
+
+fn validate_zone_id(zone_id: &str) -> Result<()> {
+    let segments = zone_id.split('-').collect::<Vec<_>>();
+    let valid_segments = segments.len() >= 2
+        && segments.iter().all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        });
+    let valid_az = segments.last().is_some_and(|segment| {
+        segment.strip_prefix("az").is_some_and(|value| {
+            !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    });
+    if !valid_segments || !valid_az {
+        return Err(Error::config_invalid("invalid S3 Express AWS Zone ID"));
+    }
+    Ok(())
+}
+
+fn region_zone_prefix(region: &str) -> Result<String> {
+    let segments = region.split('-').collect::<Vec<_>>();
+    if segments.len() < 3
+        || !segments[..segments.len() - 1].iter().all(|segment| {
+            !segment.is_empty() && segment.bytes().all(|byte| byte.is_ascii_lowercase())
+        })
+        || !segments.last().is_some_and(|segment| {
+            !segment.is_empty() && segment.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    {
+        return Err(Error::config_invalid("invalid AWS Region"));
+    }
+
+    let mut prefix = segments[0].to_string();
+    for segment in &segments[1..segments.len() - 1] {
+        prefix.push_str(match *segment {
+            "northeast" => "ne",
+            "northwest" => "nw",
+            "southeast" => "se",
+            "southwest" => "sw",
+            value => &value[..1],
+        });
+    }
+    prefix.push_str(segments.last().expect("validated Region has a suffix"));
+    Ok(prefix)
+}
+
+fn infer_region_from_zone_id(zone_id: &str) -> Option<String> {
+    let prefix = zone_id.split('-').next()?;
+    let region = match prefix {
+        "use1" => "us-east-1",
+        "use2" => "us-east-2",
+        "usw1" => "us-west-1",
+        "usw2" => "us-west-2",
+        "afs1" => "af-south-1",
+        "ape1" => "ap-east-1",
+        "apne1" => "ap-northeast-1",
+        "apne2" => "ap-northeast-2",
+        "apne3" => "ap-northeast-3",
+        "aps1" => "ap-south-1",
+        "aps2" => "ap-south-2",
+        "apse1" => "ap-southeast-1",
+        "apse2" => "ap-southeast-2",
+        "apse3" => "ap-southeast-3",
+        "apse4" => "ap-southeast-4",
+        "apse5" => "ap-southeast-5",
+        "apse7" => "ap-southeast-7",
+        "cac1" => "ca-central-1",
+        "euc1" => "eu-central-1",
+        "euc2" => "eu-central-2",
+        "eun1" => "eu-north-1",
+        "eus1" => "eu-south-1",
+        "eus2" => "eu-south-2",
+        "euw1" => "eu-west-1",
+        "euw2" => "eu-west-2",
+        "euw3" => "eu-west-3",
+        "ilc1" => "il-central-1",
+        "mec1" => "me-central-1",
+        "mes1" => "me-south-1",
+        "mxc1" => "mx-central-1",
+        "sae1" => "sa-east-1",
+        "cnn1" => "cn-north-1",
+        "cnnw1" => "cn-northwest-1",
+        _ => return None,
+    };
+    Some(region.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http::{HeaderMap, Response, Uri};
+    use reqsign_core::{
+        ErrorKind, Granter, HttpSend, ProvideCredential, Signer, SigningCredential,
+    };
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct FixedCredentialProvider {
+        credential: Option<Credential>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Debug for FixedCredentialProvider {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("FixedCredentialProvider")
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl FixedCredentialProvider {
+        fn new(credential: Credential) -> (Self, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    credential: Some(credential),
+                    calls: calls.clone(),
+                },
+                calls,
+            )
+        }
+    }
+
+    impl ProvideCredential for FixedCredentialProvider {
+        type Credential = Credential;
+
+        async fn provide_credential(&self, _ctx: &Context) -> Result<Option<Self::Credential>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.credential.clone())
+        }
+    }
+
+    #[derive(Clone)]
+    struct CapturedRequest {
+        method: Method,
+        uri: Uri,
+        headers: HeaderMap,
+        body: Bytes,
+    }
+
+    impl Debug for CapturedRequest {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("CapturedRequest")
+                .field("method", &self.method)
+                .finish_non_exhaustive()
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockHttpSend {
+        responses: Arc<Mutex<VecDeque<Response<Bytes>>>>,
+        requests: Arc<Mutex<Vec<CapturedRequest>>>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Debug for MockHttpSend {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MockHttpSend").finish_non_exhaustive()
+        }
+    }
+
+    impl MockHttpSend {
+        fn new(responses: impl IntoIterator<Item = Response<Bytes>>) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+                requests: Arc::new(Mutex::new(Vec::new())),
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn request(&self, index: usize) -> CapturedRequest {
+            self.requests.lock().expect("lock poisoned")[index].clone()
+        }
+    }
+
+    impl HttpSend for MockHttpSend {
+        async fn http_send(&self, request: Request<Bytes>) -> Result<Response<Bytes>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let (parts, body) = request.into_parts();
+            self.requests
+                .lock()
+                .expect("lock poisoned")
+                .push(CapturedRequest {
+                    method: parts.method,
+                    uri: parts.uri,
+                    headers: parts.headers,
+                    body,
+                });
+            self.responses
+                .lock()
+                .expect("lock poisoned")
+                .pop_front()
+                .ok_or_else(|| Error::unexpected("mock response queue exhausted"))
+        }
+    }
+
+    fn timestamp(value: &str) -> Timestamp {
+        value.parse().expect("timestamp must parse")
+    }
+
+    fn source_credential() -> Credential {
+        Credential {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: Some("source-session-token".to_string()),
+            expires_in: None,
+        }
+    }
+
+    fn config() -> S3ExpressSessionConfig {
+        S3ExpressSessionConfig::new(
+            "example--usw2-az1--x-s3",
+            "usw2-az1",
+            "us-west-2",
+            S3ExpressSessionPartition::Aws,
+        )
+        .expect("configuration must be valid")
+    }
+
+    fn success_response(
+        access_key_id: &str,
+        secret_access_key: &str,
+        session_token: &str,
+        expiration: &str,
+    ) -> Response<Bytes> {
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <CreateSessionResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Credentials>\
+             <SessionToken>{session_token}</SessionToken>\
+             <SecretAccessKey>{secret_access_key}</SecretAccessKey>\
+             <AccessKeyId>{access_key_id}</AccessKeyId>\
+             <Expiration>{expiration}</Expiration>\
+             </Credentials>\
+             </CreateSessionResult>"
+        );
+        Response::builder()
+            .status(StatusCode::OK)
+            .body(Bytes::from(body))
+            .expect("response must build")
+    }
+
+    fn operation(
+        mode: S3ExpressSessionMode,
+        now: Timestamp,
+        responses: impl IntoIterator<Item = Response<Bytes>>,
+    ) -> (S3ExpressSessionGranter, Context, MockHttpSend) {
+        operation_with_config(config(), mode, now, responses)
+    }
+
+    fn operation_with_config(
+        config: S3ExpressSessionConfig,
+        mode: S3ExpressSessionMode,
+        now: Timestamp,
+        responses: impl IntoIterator<Item = Response<Bytes>>,
+    ) -> (S3ExpressSessionGranter, Context, MockHttpSend) {
+        let http = MockHttpSend::new(responses);
+        let ctx = Context::new().with_http_send(http.clone());
+        let operation =
+            S3ExpressSessionGranter::new(config, S3ExpressSessionGrant::new(mode)).with_time(now);
+        (operation, ctx, http)
+    }
 
     #[test]
-    fn test_parse_region_from_az_id() {
-        let provider = S3ExpressSessionProvider::new(
-            "test--usw2-az1--x-s3",
-            crate::StaticCredentialProvider::new("test", "test"),
+    fn validates_typed_mode_partition_and_configuration() {
+        assert_eq!(
+            "ReadOnly".parse::<S3ExpressSessionMode>().unwrap(),
+            S3ExpressSessionMode::ReadOnly
+        );
+        assert_eq!(
+            "ReadWrite".parse::<S3ExpressSessionMode>().unwrap(),
+            S3ExpressSessionMode::ReadWrite
+        );
+        assert_eq!(
+            "read-write"
+                .parse::<S3ExpressSessionMode>()
+                .expect_err("wire modes are case sensitive")
+                .kind(),
+            ErrorKind::ConfigInvalid
+        );
+        assert_eq!(
+            "aws".parse::<S3ExpressSessionPartition>().unwrap(),
+            S3ExpressSessionPartition::Aws
+        );
+        assert_eq!(
+            "aws-cn".parse::<S3ExpressSessionPartition>().unwrap(),
+            S3ExpressSessionPartition::AwsCn
+        );
+        assert_eq!(
+            S3ExpressSessionPartition::from_region("us-west-2").unwrap(),
+            S3ExpressSessionPartition::Aws
+        );
+        assert_eq!(
+            S3ExpressSessionPartition::from_region("cn-north-1").unwrap(),
+            S3ExpressSessionPartition::AwsCn
+        );
+        assert_eq!(S3ExpressSessionPartition::Aws.as_str(), "aws");
+        assert_eq!(
+            S3ExpressSessionPartition::AwsCn.dns_suffix(),
+            "amazonaws.com.cn"
+        );
+        for value in ["aws-us-gov", "aws-eusc", "AWS"] {
+            assert_eq!(
+                value
+                    .parse::<S3ExpressSessionPartition>()
+                    .expect_err("unsupported partition must fail")
+                    .kind(),
+                ErrorKind::ConfigInvalid
+            );
+        }
+        for region in ["us-gov-west-1", "eusc-de-east-1", "US-WEST-2"] {
+            assert_eq!(
+                S3ExpressSessionPartition::from_region(region)
+                    .expect_err("unsupported or malformed partition Region must fail")
+                    .kind(),
+                ErrorKind::ConfigInvalid
+            );
+        }
+
+        let config = config();
+        assert_eq!(config.bucket(), "example--usw2-az1--x-s3");
+        assert_eq!(config.zone_id(), "usw2-az1");
+        assert_eq!(config.region(), "us-west-2");
+        assert_eq!(config.partition(), S3ExpressSessionPartition::Aws);
+        assert_eq!(
+            config.endpoint(),
+            "https://example--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com"
         );
 
+        let local_zone = S3ExpressSessionConfig::new(
+            "example--usw2-lax1-az1--x-s3",
+            "usw2-lax1-az1",
+            "us-west-2",
+            S3ExpressSessionPartition::Aws,
+        )
+        .expect("Local Zone IDs must be supported");
+        assert_eq!(local_zone.zone_id(), "usw2-lax1-az1");
+
+        let china = S3ExpressSessionConfig::new(
+            "example--cnn1-pkx1-az1--x-s3",
+            "cnn1-pkx1-az1",
+            "cn-north-1",
+            S3ExpressSessionPartition::AwsCn,
+        )
+        .expect("AWS China Local Zone configuration must be supported");
+        assert_eq!(china.partition(), S3ExpressSessionPartition::AwsCn);
         assert_eq!(
-            provider.parse_region_from_az_id("usw2-az1").unwrap(),
-            "us-west-2"
+            china.endpoint(),
+            "https://example--cnn1-pkx1-az1--x-s3.s3express-cnn1-pkx1-az1.cn-north-1.amazonaws.com.cn"
+        );
+
+        for (bucket, zone_id, region, partition) in [
+            (
+                "general-purpose-bucket",
+                "usw2-az1",
+                "us-west-2",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "UPPER--usw2-az1--x-s3",
+                "usw2-az1",
+                "us-west-2",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "xn--name--usw2-az1--x-s3",
+                "usw2-az1",
+                "us-west-2",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "example--usw2-az1--x-s3",
+                "use1-az4",
+                "us-west-2",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "example--usw2-zone1--x-s3",
+                "usw2-zone1",
+                "us-west-2",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "example--usw2-az1--x-s3",
+                "usw2-az1",
+                "us-east-1",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "example--usw2-az1--x-s3",
+                "usw2-az1",
+                "US-WEST-2",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "example--cnn1-pkx1-az1--x-s3",
+                "cnn1-pkx1-az1",
+                "cn-north-1",
+                S3ExpressSessionPartition::Aws,
+            ),
+            (
+                "example--usw2-az1--x-s3",
+                "usw2-az1",
+                "us-west-2",
+                S3ExpressSessionPartition::AwsCn,
+            ),
+            (
+                "example--usgw1-az1--x-s3",
+                "usgw1-az1",
+                "us-gov-west-1",
+                S3ExpressSessionPartition::Aws,
+            ),
+        ] {
+            assert_eq!(
+                S3ExpressSessionConfig::new(bucket, zone_id, region, partition)
+                    .expect_err("invalid fixed configuration must fail")
+                    .kind(),
+                ErrorKind::ConfigInvalid
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn builds_and_signs_exact_create_session_request() {
+        let now = timestamp("2030-01-01T00:00:00Z");
+        let (operation, ctx, http) = operation(
+            S3ExpressSessionMode::ReadOnly,
+            now,
+            [success_response(
+                "session-access-key",
+                "session-secret-key",
+                "granted-session-token",
+                "2030-01-01T00:05:00Z",
+            )],
+        );
+
+        let output = operation
+            .grant_credential(&ctx, &source_credential(), None)
+            .await
+            .expect("CreateSession must succeed");
+        assert_eq!(output.access_key_id, "session-access-key");
+        assert_eq!(output.secret_access_key, "session-secret-key");
+        assert_eq!(
+            output.session_token.as_deref(),
+            Some("granted-session-token")
+        );
+        assert_eq!(output.expires_in, Some(timestamp("2030-01-01T00:05:00Z")));
+
+        let request = http.request(0);
+        assert_eq!(request.method, Method::GET);
+        assert_eq!(
+            request.uri,
+            "https://example--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com/?session"
+                .parse::<Uri>()
+                .unwrap()
+        );
+        assert!(request.body.is_empty());
+        assert_eq!(
+            request.headers[header::HOST],
+            "example--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com"
         );
         assert_eq!(
-            provider.parse_region_from_az_id("use1-az4").unwrap(),
-            "us-east-1"
+            request.headers["x-amz-content-sha256"],
+            crate::EMPTY_STRING_SHA256
+        );
+        assert_eq!(request.headers["x-amz-create-session-mode"], "ReadOnly");
+        assert_eq!(request.headers["x-amz-date"], "20300101T000000Z");
+        assert_eq!(
+            request.headers["x-amz-security-token"],
+            "source-session-token"
+        );
+        assert!(request.headers["x-amz-security-token"].is_sensitive());
+        assert!(!request.headers.contains_key("x-amz-s3session-token"));
+        assert!(request.headers[header::AUTHORIZATION].is_sensitive());
+        assert_eq!(
+            request.headers[header::AUTHORIZATION]
+                .to_str()
+                .expect("authorization must be ASCII"),
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20300101/us-west-2/s3express/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-create-session-mode;x-amz-date;x-amz-security-token, Signature=9dbbac1f6c2300e0bdbc43bbd4f44384ce8ca6d4820447478a90e616ecb89acc"
+        );
+    }
+
+    #[tokio::test]
+    async fn builds_and_signs_exact_aws_china_create_session_request() {
+        let now = timestamp("2030-01-01T00:00:00Z");
+        let config = S3ExpressSessionConfig::new(
+            "example--cnn1-pkx1-az1--x-s3",
+            "cnn1-pkx1-az1",
+            "cn-north-1",
+            S3ExpressSessionPartition::AwsCn,
+        )
+        .expect("AWS China configuration must be valid");
+        let (operation, ctx, http) = operation_with_config(
+            config,
+            S3ExpressSessionMode::ReadOnly,
+            now,
+            [success_response(
+                "session-access-key",
+                "session-secret-key",
+                "granted-session-token",
+                "2030-01-01T00:05:00Z",
+            )],
+        );
+
+        operation
+            .grant_credential(&ctx, &source_credential(), None)
+            .await
+            .expect("AWS China CreateSession must succeed");
+
+        let request = http.request(0);
+        assert_eq!(request.method, Method::GET);
+        assert_eq!(
+            request.uri,
+            "https://example--cnn1-pkx1-az1--x-s3.s3express-cnn1-pkx1-az1.cn-north-1.amazonaws.com.cn/?session"
+                .parse::<Uri>()
+                .unwrap()
         );
         assert_eq!(
-            provider.parse_region_from_az_id("euw1-az2").unwrap(),
-            "eu-west-1"
+            request.headers[header::HOST],
+            "example--cnn1-pkx1-az1--x-s3.s3express-cnn1-pkx1-az1.cn-north-1.amazonaws.com.cn"
+        );
+        assert_eq!(request.headers["x-amz-create-session-mode"], "ReadOnly");
+        assert_eq!(
+            request.headers[header::AUTHORIZATION]
+                .to_str()
+                .expect("authorization must be ASCII"),
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20300101/cn-north-1/s3express/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-create-session-mode;x-amz-date;x-amz-security-token, Signature=110a8acca9067dccbd29dfa3d93f7b5f681fe7d3efcf86e50fb90b4de52831aa"
         );
     }
 
     #[test]
-    fn test_invalid_bucket_format() {
-        let provider = S3ExpressSessionProvider::new(
-            "invalid-bucket-name",
-            crate::StaticCredentialProvider::new("test", "test"),
+    fn parses_credentials_and_exact_expiration() {
+        let body = success_response(
+            "session-access-key",
+            "session-secret-key",
+            "session-token",
+            "2030-01-01T00:05:00Z",
+        )
+        .into_body();
+        let credential = parse_create_session_response(&body, timestamp("2030-01-01T00:00:01Z"))
+            .expect("valid response must parse");
+        assert_eq!(credential.access_key_id, "session-access-key");
+        assert_eq!(credential.secret_access_key, "session-secret-key");
+        assert_eq!(credential.session_token.as_deref(), Some("session-token"));
+        assert_eq!(
+            credential.expires_in,
+            Some(timestamp("2030-01-01T00:05:00Z"))
         );
-
-        // This will be tested when create_session is called
-        // Just verify the provider can be created
-        assert_eq!(provider.bucket, "invalid-bucket-name");
+        assert!(credential.is_valid_at(timestamp("2030-01-01T00:04:59Z")));
+        assert!(!credential.is_valid_at(timestamp("2030-01-01T00:05:00Z")));
     }
 
     #[test]
-    fn test_parse_create_session_response() {
-        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-            <CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                <Credentials>
-                    <SessionToken>TESTSESSIONTOKEN</SessionToken>
-                    <SecretAccessKey>TESTSECRETKEY</SecretAccessKey>
-                    <AccessKeyId>ASIARTESTID</AccessKeyId>
-                    <Expiration>2024-01-29T18:53:01Z</Expiration>
-                </Credentials>
-            </CreateSessionResult>"#;
+    fn rejects_malformed_incomplete_and_expired_responses_without_leaking_them() {
+        let validated_at = timestamp("2030-01-01T00:05:00Z");
+        let responses = [
+            b"<not-create-session>raw-response-secret</not-create-session>".to_vec(),
+            success_response(
+                "",
+                "sensitive-secret-key",
+                "sensitive-session-token",
+                "2030-01-01T00:06:00Z",
+            )
+            .into_body()
+            .to_vec(),
+            success_response(
+                "sensitive-access-key",
+                "sensitive-secret-key",
+                "sensitive-session-token",
+                "not-a-timestamp",
+            )
+            .into_body()
+            .to_vec(),
+            success_response(
+                "sensitive-access-key",
+                "sensitive-secret-key",
+                "sensitive-session-token",
+                "2030-01-01T00:05:00Z",
+            )
+            .into_body()
+            .to_vec(),
+        ];
 
-        let response: CreateSessionResponse = quick_xml::de::from_str(xml).unwrap();
-        assert_eq!(response.credentials.access_key_id, "ASIARTESTID");
-        assert_eq!(response.credentials.secret_access_key, "TESTSECRETKEY");
-        assert_eq!(response.credentials.session_token, "TESTSESSIONTOKEN");
-        assert_eq!(response.credentials.expiration, "2024-01-29T18:53:01Z");
+        for response in responses {
+            let err = parse_create_session_response(&response, validated_at)
+                .expect_err("unusable response must fail closed");
+            let debug = format!("{err:?}");
+            for secret in [
+                "raw-response-secret",
+                "sensitive-access-key",
+                "sensitive-secret-key",
+                "sensitive-session-token",
+                "not-a-timestamp",
+            ] {
+                assert!(!debug.contains(secret));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_lifetime_and_source_before_io() {
+        let now = timestamp("2030-01-01T00:00:00Z");
+        let (operation, ctx, http) = operation(S3ExpressSessionMode::ReadWrite, now, []);
+
+        let err = operation
+            .grant_credential(&ctx, &source_credential(), Some(Duration::from_secs(300)))
+            .await
+            .expect_err("CreateSession lifetime is service fixed");
+        assert_eq!(err.kind(), ErrorKind::RequestInvalid);
+
+        for source in [
+            Credential::default(),
+            Credential {
+                session_token: Some(String::new()),
+                ..source_credential()
+            },
+            Credential {
+                expires_in: Some(now + Duration::from_secs(10)),
+                ..source_credential()
+            },
+        ] {
+            let err = operation
+                .grant_credential(&ctx, &source, None)
+                .await
+                .expect_err("invalid AWS source credential must fail before I/O");
+            assert_eq!(err.kind(), ErrorKind::CredentialInvalid);
+        }
+        assert_eq!(http.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn rejects_output_that_expires_during_io() {
+        let now = timestamp("2030-01-01T00:00:00Z");
+        let completed_at = timestamp("2030-01-01T00:05:00Z");
+        let (operation, ctx, http) = operation(
+            S3ExpressSessionMode::ReadWrite,
+            now,
+            [success_response(
+                "session-access-key",
+                "session-secret-key",
+                "session-token",
+                "2030-01-01T00:05:00Z",
+            )],
+        );
+        let operation = operation.with_time_after_request(completed_at);
+
+        let err = operation
+            .grant_credential(&ctx, &source_credential(), None)
+            .await
+            .expect_err("credential expired at I/O completion must be rejected");
+        assert_eq!(err.kind(), ErrorKind::CredentialInvalid);
+        assert_eq!(http.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn errors_redact_raw_response_and_session_material() {
+        let now = timestamp("2030-01-01T00:00:00Z");
+        let denied = Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Bytes::from_static(
+                b"<Error><Message>raw-response-secret</Message></Error>",
+            ))
+            .unwrap();
+        let (operation, ctx, http) = operation(S3ExpressSessionMode::ReadWrite, now, [denied]);
+        let source = source_credential();
+
+        let err = operation
+            .grant_credential(&ctx, &source, None)
+            .await
+            .expect_err("denied CreateSession must fail");
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+        let request = http.request(0);
+        let response = CreateSessionResponse {
+            credentials: SessionCredentials {
+                session_token: "sensitive-session-token".to_string(),
+                secret_access_key: "sensitive-secret-key".to_string(),
+                access_key_id: "sensitive-access-key".to_string(),
+                expiration: "sensitive-expiration".to_string(),
+            },
+        };
+        let provider = S3ExpressSessionProvider::new(
+            "sensitive-bucket--usw2-az1--x-s3",
+            FixedCredentialProvider::new(source.clone()).0,
+        );
+
+        for (debug, secret) in [
+            (format!("{:?}", config()), "example--usw2-az1--x-s3"),
+            (
+                format!(
+                    "{:?}",
+                    S3ExpressSessionGrant::new(S3ExpressSessionMode::ReadWrite)
+                ),
+                "ReadWrite",
+            ),
+            (format!("{operation:?}"), "example--usw2-az1--x-s3"),
+            (format!("{provider:?}"), "sensitive-bucket"),
+            (format!("{source:?}"), "source-session-token"),
+            (format!("{request:?}"), "source-session-token"),
+            (format!("{response:?}"), "sensitive-session-token"),
+            (format!("{response:?}"), "sensitive-secret-key"),
+            (format!("{response:?}"), "sensitive-access-key"),
+            (format!("{response:?}"), "sensitive-expiration"),
+            (format!("{err:?}"), "raw-response-secret"),
+        ] {
+            assert!(!debug.contains(secret));
+        }
+    }
+
+    #[test]
+    fn classifies_create_session_status_errors_for_retry() {
+        for (status, kind, retryable) in [
+            (StatusCode::FORBIDDEN, ErrorKind::PermissionDenied, false),
+            (StatusCode::TOO_MANY_REQUESTS, ErrorKind::RateLimited, true),
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorKind::Unexpected,
+                true,
+            ),
+            (StatusCode::SERVICE_UNAVAILABLE, ErrorKind::Unexpected, true),
+            (StatusCode::BAD_REQUEST, ErrorKind::Unexpected, false),
+        ] {
+            let err = create_session_status_error(status);
+            assert_eq!(err.kind(), kind);
+            assert_eq!(err.is_retryable(), retryable);
+            assert_eq!(err.context(), &[format!("status: {}", status.as_u16())]);
+        }
+    }
+
+    #[tokio::test]
+    async fn preserves_fixed_flow_provider_compatibility() {
+        let response = success_response(
+            "session-access-key",
+            "session-secret-key",
+            "session-token",
+            "2099-01-01T00:05:00Z",
+        );
+        let http = MockHttpSend::new([response]);
+        let ctx = Context::new().with_http_send(http.clone());
+        let (source_provider, source_calls) = FixedCredentialProvider::new(source_credential());
+        let provider = S3ExpressSessionProvider::new("example--usw2-az1--x-s3", source_provider);
+
+        let output = provider
+            .provide_credential(&ctx)
+            .await
+            .expect("compatibility provider must succeed")
+            .expect("compatibility provider must return a credential");
+        assert_eq!(output.access_key_id, "session-access-key");
+        assert_eq!(source_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(http.calls.load(Ordering::SeqCst), 1);
+        let request = http.request(0);
+        assert_eq!(request.headers["x-amz-create-session-mode"], "ReadWrite");
+        assert_eq!(
+            request.uri.authority().unwrap().as_str(),
+            "example--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn compatibility_provider_resolves_aws_china_partition() {
+        let response = success_response(
+            "session-access-key",
+            "session-secret-key",
+            "session-token",
+            "2099-01-01T00:05:00Z",
+        );
+        let http = MockHttpSend::new([response]);
+        let ctx = Context::new().with_http_send(http.clone());
+        let (source_provider, source_calls) = FixedCredentialProvider::new(source_credential());
+        let provider =
+            S3ExpressSessionProvider::new("example--cnn1-pkx1-az1--x-s3", source_provider);
+
+        provider
+            .provide_credential(&ctx)
+            .await
+            .expect("AWS China compatibility provider must succeed")
+            .expect("AWS China compatibility provider must return a credential");
+
+        assert_eq!(source_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(http.calls.load(Ordering::SeqCst), 1);
+        let request = http.request(0);
+        assert_eq!(
+            request.uri.authority().unwrap().as_str(),
+            "example--cnn1-pkx1-az1--x-s3.s3express-cnn1-pkx1-az1.cn-north-1.amazonaws.com.cn"
+        );
+        assert!(
+            request.headers[header::AUTHORIZATION]
+                .to_str()
+                .expect("authorization must be ASCII")
+                .contains("/cn-north-1/s3express/aws4_request")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_validates_configuration_before_loading_source() {
+        let http = MockHttpSend::new([]);
+        let ctx = Context::new().with_http_send(http.clone());
+        let (source_provider, source_calls) = FixedCredentialProvider::new(source_credential());
+        let provider = S3ExpressSessionProvider::new("invalid-bucket", source_provider);
+
+        let err = provider
+            .provide_credential(&ctx)
+            .await
+            .expect_err("invalid fixed configuration must fail");
+        assert_eq!(err.kind(), ErrorKind::ConfigInvalid);
+        assert_eq!(source_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(http.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn provider_rejects_unsupported_partition_before_loading_source() {
+        let http = MockHttpSend::new([]);
+        let ctx = Context::new().with_http_send(http.clone());
+        let (source_provider, source_calls) = FixedCredentialProvider::new(source_credential());
+        let provider = S3ExpressSessionProvider::new("example--usgw1-az1--x-s3", source_provider)
+            .with_region("us-gov-west-1");
+
+        let err = provider
+            .provide_credential(&ctx)
+            .await
+            .expect_err("unsupported S3 Express partition must fail");
+        assert_eq!(err.kind(), ErrorKind::ConfigInvalid);
+        assert_eq!(source_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(http.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn granter_never_caches_outputs_and_existing_signer_consumes_them() {
+        let now = timestamp("2030-01-01T00:00:00Z");
+        let response = || {
+            success_response(
+                "session-access-key",
+                "session-secret-key",
+                "granted-session-token",
+                "2099-01-01T00:05:00Z",
+            )
+        };
+        let http = MockHttpSend::new([response(), response()]);
+        let ctx = Context::new().with_http_send(http.clone());
+        let operation = S3ExpressSessionGranter::new(
+            config(),
+            S3ExpressSessionGrant::new(S3ExpressSessionMode::ReadWrite),
+        )
+        .with_time(now);
+        let (source_provider, source_calls) = FixedCredentialProvider::new(source_credential());
+        let granter = Granter::new(ctx, source_provider, operation);
+
+        let output = granter.grant(None).await.expect("first grant must succeed");
+        granter
+            .grant(None)
+            .await
+            .expect("second grant must issue another session");
+        assert_eq!(source_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(http.calls.load(Ordering::SeqCst), 2);
+
+        let (output_provider, _) = FixedCredentialProvider::new(output);
+        let signer = Signer::new(
+            Context::new(),
+            output_provider,
+            crate::RequestSigner::new("s3express", "us-west-2"),
+        );
+        let mut parts = Request::get(
+            "https://example--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com/object",
+        )
+        .body(())
+        .unwrap()
+        .into_parts()
+        .0;
+        signer
+            .sign(&mut parts, None)
+            .await
+            .expect("existing AWS signer must consume granted credentials");
+
+        assert_eq!(
+            parts.headers["x-amz-s3session-token"],
+            "granted-session-token"
+        );
+        assert!(parts.headers["x-amz-s3session-token"].is_sensitive());
+        assert!(!parts.headers.contains_key("x-amz-security-token"));
+        assert!(parts.headers.contains_key(header::AUTHORIZATION));
     }
 }

--- a/services/aws-v4/tests/credential_providers/s3_express.rs
+++ b/services/aws-v4/tests/credential_providers/s3_express.rs
@@ -17,8 +17,12 @@
 
 use super::create_test_context;
 use log::info;
-use reqsign_aws_v4::{DefaultCredentialProvider, S3ExpressSessionProvider};
-use reqsign_core::ProvideCredential;
+use reqsign_aws_v4::{
+    DefaultCredentialProvider, S3ExpressSessionConfig, S3ExpressSessionGrant,
+    S3ExpressSessionGranter, S3ExpressSessionMode, S3ExpressSessionPartition,
+    S3ExpressSessionProvider,
+};
+use reqsign_core::{Granter, ProvideCredential};
 use std::env;
 
 #[tokio::test]
@@ -45,6 +49,52 @@ async fn test_s3_express_session_provider() {
         "S3ExpressSessionProvider should return credentials"
     );
     let cred = cred.unwrap();
+    assert!(!cred.access_key_id.is_empty());
+    assert!(!cred.secret_access_key.is_empty());
+    assert!(
+        cred.session_token.is_some(),
+        "S3 Express session should include session token"
+    );
+    assert!(
+        cred.expires_in.is_some(),
+        "S3 Express session should have expiration"
+    );
+}
+
+#[tokio::test]
+async fn test_s3_express_session_granter() {
+    if env::var("REQSIGN_AWS_V4_TEST_S3_EXPRESS").unwrap_or_default() != "on" {
+        info!("REQSIGN_AWS_V4_TEST_S3_EXPRESS not set, skipping");
+        return;
+    }
+
+    let bucket = env::var("REQSIGN_AWS_V4_S3_EXPRESS_BUCKET")
+        .expect("REQSIGN_AWS_V4_S3_EXPRESS_BUCKET must be set for S3 Express test");
+    let region =
+        env::var("AWS_REGION").expect("AWS_REGION must be set for S3 Express granter test");
+    let zone_id = bucket
+        .strip_suffix("--x-s3")
+        .and_then(|value| value.rsplit_once("--"))
+        .map(|(_, zone_id)| zone_id)
+        .expect("S3 Express bucket must include its Zone ID");
+    let partition = S3ExpressSessionPartition::from_region(&region)
+        .expect("S3 Express partition must be supported");
+    let config = S3ExpressSessionConfig::new(&bucket, zone_id, region, partition)
+        .expect("S3 Express configuration must be valid");
+    let operation = S3ExpressSessionGranter::new(
+        config,
+        S3ExpressSessionGrant::new(S3ExpressSessionMode::ReadWrite),
+    );
+    let granter = Granter::new(
+        create_test_context(),
+        DefaultCredentialProvider::new(),
+        operation,
+    );
+
+    let cred = granter
+        .grant(None)
+        .await
+        .expect("S3ExpressSessionGranter should create a session");
     assert!(!cred.access_key_id.is_empty());
     assert!(!cred.secret_access_key.is_empty());
     assert!(


### PR DESCRIPTION
## Context

S3 Express `CreateSession` already had a fixed-flow credential provider, but callers could not use it through the scoped credential-granting architecture introduced in #803. This makes the issuance path available as a service-specific `GrantCredential` implementation while preserving `S3ExpressSessionProvider` for compatibility.

The session configuration binds the directory bucket, Zone ID, Region, and AWS partition before source credential loading, preventing China Regions from being sent to the standard `amazonaws.com` DNS suffix. The grant keeps AWS's explicit `ReadOnly`/`ReadWrite` modes, exact credential expiration, redacted error handling, and direct composition with the existing AWS signer. Transient `CreateSession` service failures remain retryable.

This advances the S3 Express item in #807. Historical protocol context is in #594.

Live AWS acceptance remains gated on access to an authorized directory bucket; deterministic request/signing, expiration, redaction, provider compatibility, and standard/AWS China endpoint coverage are included locally.
