### PR TITLE
fix(docs): migrate from doc_auto_cfg to doc_cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,9 @@ jobs:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
       - name: Doc Test
-        run: cargo test --doc --all-features --workspace
+        run: cargo +nightly test --doc --all-features --workspace
         env:
+          RUSTDOCFLAGS: --cfg docsrs
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
 

--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -31,6 +31,7 @@ rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Core functionality (always included)

--- a/reqsign/src/lib.rs
+++ b/reqsign/src/lib.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Re-export core types
 pub use reqsign_core::*;


### PR DESCRIPTION
Close #831 

## Error

```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps
```

```
error[E0557]: feature has been removed
  --> reqsign/src/lib.rs:19:29
   |
19 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in 1.92.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc

For more information about this error, try `rustc --explain E0557`.
error: could not document `reqsign`
```