### PR TITLE
feat(google): add service account token provider

### DIFF
--- a/services/google/src/credential.rs
+++ b/services/google/src/credential.rs
@@ -268,12 +268,11 @@ impl KeyTrait for Token {
 /// - Service account only: Used for signed URL generation and JWT-based authentication
 /// - Token only: Used for Bearer authentication (e.g., from metadata server, OAuth2)
 /// - Token with signer email: Also supports query signing through IAMCredentials `signBlob`
-/// - Both: The RequestSigner is responsible for exchanging service account for tokens when needed,
-///   and can use cached tokens when available to avoid unnecessary exchanges
+/// - Both: The RequestSigner can exchange the service account when the attached token is unusable
 ///
-/// The RequestSigner implementation handles the logic of when to use which credential type
-/// and when to perform token exchanges. Providers should return credentials as they receive them
-/// without trying to perform exchanges themselves.
+/// Loading providers normally preserve the credential variant they discover. Explicit conversion
+/// providers may return a new variant, such as a token-only credential produced from a service
+/// account.
 #[derive(Clone, Debug, Default)]
 pub struct Credential {
     /// Service account information, if available.

--- a/services/google/src/credential.rs
+++ b/services/google/src/credential.rs
@@ -268,11 +268,13 @@ impl KeyTrait for Token {
 /// - Service account only: Used for signed URL generation and JWT-based authentication
 /// - Token only: Used for Bearer authentication (e.g., from metadata server, OAuth2)
 /// - Token with signer email: Also supports query signing through IAMCredentials `signBlob`
-/// - Both: The RequestSigner can exchange the service account when the attached token is unusable
+/// - Both: The RequestSigner is responsible for exchanging service account for tokens when needed,
+///   and can use cached tokens when available to avoid unnecessary exchanges
 ///
-/// Loading providers normally preserve the credential variant they discover. Explicit conversion
-/// providers may return a new variant, such as a token-only credential produced from a service
-/// account.
+/// The RequestSigner implementation handles the logic of when to use which credential type
+/// and when to perform token exchanges. Discovery providers should return credentials as they
+/// receive them without trying to perform exchanges themselves. Explicit conversion providers may
+/// return a new variant, such as a token-only credential produced from a service account.
 #[derive(Clone, Debug, Default)]
 pub struct Credential {
     /// Service account information, if available.

--- a/services/google/src/lib.rs
+++ b/services/google/src/lib.rs
@@ -40,6 +40,6 @@ pub use sign_request::RequestSigner;
 mod provide_credential;
 pub use provide_credential::{
     DefaultCredentialProvider, DefaultCredentialProviderBuilder, EnvCredentialProvider,
-    FileCredentialProvider, StaticCredentialProvider, TokenCredentialProvider,
-    VmMetadataCredentialProvider, WellKnownCredentialProvider,
+    FileCredentialProvider, ServiceAccountTokenCredentialProvider, StaticCredentialProvider,
+    TokenCredentialProvider, VmMetadataCredentialProvider, WellKnownCredentialProvider,
 };

--- a/services/google/src/provide_credential/mod.rs
+++ b/services/google/src/provide_credential/mod.rs
@@ -38,7 +38,7 @@ pub use token::TokenCredentialProvider;
 
 mod service_account_token;
 pub use service_account_token::ServiceAccountTokenCredentialProvider;
-pub(crate) use service_account_token::{exchange_service_account_token, resolve_scope};
+pub(crate) use service_account_token::exchange_service_account_token;
 
 // Internal providers - not exported
 mod authorized_user;

--- a/services/google/src/provide_credential/mod.rs
+++ b/services/google/src/provide_credential/mod.rs
@@ -36,6 +36,10 @@ pub use static_provider::StaticCredentialProvider;
 mod token;
 pub use token::TokenCredentialProvider;
 
+mod service_account_token;
+pub use service_account_token::ServiceAccountTokenCredentialProvider;
+pub(crate) use service_account_token::{exchange_service_account_token, resolve_scope};
+
 // Internal providers - not exported
 mod authorized_user;
 mod external_account;

--- a/services/google/src/provide_credential/mod.rs
+++ b/services/google/src/provide_credential/mod.rs
@@ -38,7 +38,6 @@ pub use token::TokenCredentialProvider;
 
 mod service_account_token;
 pub use service_account_token::ServiceAccountTokenCredentialProvider;
-pub(crate) use service_account_token::exchange_service_account_token;
 
 // Internal providers - not exported
 mod authorized_user;

--- a/services/google/src/provide_credential/service_account_token.rs
+++ b/services/google/src/provide_credential/service_account_token.rs
@@ -228,7 +228,7 @@ fn resolve_scope(ctx: &Context, scope: Option<&str>) -> String {
         .unwrap_or_else(|| DEFAULT_SCOPE.to_string())
 }
 
-pub(crate) async fn exchange_service_account_token(
+async fn exchange_service_account_token(
     ctx: &Context,
     service_account: &ServiceAccount,
     scope: Option<&str>,
@@ -378,7 +378,7 @@ mod tests {
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use reqsign_core::hash::base64_decode;
-    use reqsign_core::{FileRead, Granter, HttpSend, SignRequest, StaticEnv, time::Timestamp};
+    use reqsign_core::{FileRead, Granter, HttpSend, StaticEnv, time::Timestamp};
     use rsa::RsaPrivateKey;
     use rsa::pkcs8::{EncodePrivateKey, LineEnding};
     use rsa::rand_core::OsRng;
@@ -386,7 +386,7 @@ mod tests {
 
     use crate::{
         CredentialAccessBoundaryGrant, CredentialAccessBoundaryPermissions,
-        DefaultCredentialProvider, FileCredentialProvider, RequestSigner,
+        DefaultCredentialProvider, FileCredentialProvider,
         ServerSideCredentialAccessBoundaryGranter, StaticCredentialProvider,
     };
 
@@ -799,33 +799,6 @@ mod tests {
             form_fields(&requests[1].body)["subject_token"],
             "source-token"
         );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn request_signer_uses_shared_service_account_exchange() -> Result<()> {
-        let http = MockHttpSend::new([oauth_success("source-token", 3600)]);
-        let credential = Credential::with_service_account(service_account());
-        let mut request = http::Request::get("https://storage.googleapis.com/bucket/object")
-            .body(())?
-            .into_parts()
-            .0;
-
-        RequestSigner::new("storage")
-            .sign_request(
-                &Context::new().with_http_send(http.clone()),
-                &mut request,
-                Some(&credential),
-                None,
-            )
-            .await?;
-
-        assert_eq!(
-            request.headers[http::header::AUTHORIZATION],
-            "Bearer source-token"
-        );
-        assert_eq!(http.requests().len(), 1);
-        assert_eq!(http.requests()[0].uri, OAUTH_TOKEN_ENDPOINT);
         Ok(())
     }
 }

--- a/services/google/src/provide_credential/service_account_token.rs
+++ b/services/google/src/provide_credential/service_account_token.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::{self, Debug, Formatter};
-use std::sync::Arc;
 use std::time::Duration;
 
 use form_urlencoded::Serializer;
@@ -88,10 +87,9 @@ struct OAuthErrorResponse {
     error: Option<String>,
 }
 
-#[derive(Clone)]
 enum Source {
     ServiceAccount(ServiceAccount),
-    Provider(Arc<dyn ProvideCredentialDyn<Credential = Credential>>),
+    Provider(Box<dyn ProvideCredentialDyn<Credential = Credential>>),
 }
 
 /// Exchanges a service-account credential for an OAuth access token.
@@ -138,7 +136,6 @@ enum Source {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone)]
 pub struct ServiceAccountTokenCredentialProvider {
     source: Source,
     scope: Option<String>,
@@ -170,7 +167,7 @@ impl ServiceAccountTokenCredentialProvider {
         provider: impl ProvideCredential<Credential = Credential> + 'static,
     ) -> Self {
         Self {
-            source: Source::Provider(Arc::new(provider)),
+            source: Source::Provider(Box::new(provider)),
             scope: None,
         }
     }
@@ -216,15 +213,15 @@ impl ProvideCredential for ServiceAccountTokenCredentialProvider {
         let Some(service_account) = self.service_account(ctx).await? else {
             return Ok(None);
         };
-        let scope = resolve_scope(ctx, self.scope.as_deref());
-        let token = exchange_service_account_token(ctx, &service_account, &scope).await?;
+        let token =
+            exchange_service_account_token(ctx, &service_account, self.scope.as_deref()).await?;
         Ok(Some(
             Credential::with_token(token).with_signer_email(service_account.client_email),
         ))
     }
 }
 
-pub(crate) fn resolve_scope(ctx: &Context, scope: Option<&str>) -> String {
+fn resolve_scope(ctx: &Context, scope: Option<&str>) -> String {
     scope
         .map(ToOwned::to_owned)
         .or_else(|| ctx.env_var(GOOGLE_SCOPE))
@@ -234,7 +231,7 @@ pub(crate) fn resolve_scope(ctx: &Context, scope: Option<&str>) -> String {
 pub(crate) async fn exchange_service_account_token(
     ctx: &Context,
     service_account: &ServiceAccount,
-    scope: &str,
+    scope: Option<&str>,
 ) -> Result<Token> {
     if !service_account.is_valid() {
         return Err(Error::credential_invalid(
@@ -242,8 +239,9 @@ pub(crate) async fn exchange_service_account_token(
         ));
     }
 
+    let scope = resolve_scope(ctx, scope);
     debug!("exchanging service account for token with scope: {scope}");
-    let request = build_token_request(service_account, scope, Timestamp::now())?;
+    let request = build_token_request(service_account, &scope, Timestamp::now())?;
     let request_started_at = Timestamp::now();
     let response = ctx.http_send(request).await.map_err(|err| {
         Error::new(err.kind(), "service account OAuth token request failed")
@@ -255,7 +253,12 @@ pub(crate) async fn exchange_service_account_token(
         return Err(oauth_error(response.status(), response.body()));
     }
     let token = parse_token_response(response.body(), request_started_at)?;
-    validate_token(&token, completed_at)?;
+    let required_until = checked_expiration(completed_at, TOKEN_OPERATION_HEADROOM)?;
+    if !token.is_valid_at(required_until) {
+        return Err(Error::credential_invalid(
+            "service account OAuth token is not valid long enough for Google signing",
+        ));
+    }
     Ok(token)
 }
 
@@ -299,16 +302,6 @@ fn parse_token_response(body: &[u8], request_started_at: Timestamp) -> Result<To
         access_token: response.access_token,
         expires_at: Some(expires_at),
     })
-}
-
-fn validate_token(token: &Token, completed_at: Timestamp) -> Result<()> {
-    let required_until = checked_expiration(completed_at, TOKEN_OPERATION_HEADROOM)?;
-    if !token.is_valid_at(required_until) {
-        return Err(Error::credential_invalid(
-            "service account OAuth token is not valid long enough for Google signing",
-        ));
-    }
-    Ok(())
 }
 
 fn checked_expiration(started_at: Timestamp, expires_in: Duration) -> Result<Timestamp> {

--- a/services/google/src/provide_credential/service_account_token.rs
+++ b/services/google/src/provide_credential/service_account_token.rs
@@ -1,0 +1,838 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
+use std::time::Duration;
+
+use form_urlencoded::Serializer;
+use http::header::CONTENT_TYPE;
+use log::debug;
+use reqsign_core::time::Timestamp;
+use reqsign_core::{
+    Context, Error, ErrorKind, ProvideCredential, ProvideCredentialDyn, Result, SigningCredential,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::constants::{DEFAULT_SCOPE, GOOGLE_SCOPE, TOKEN_OPERATION_HEADROOM};
+use crate::credential::{Credential, ServiceAccount, Token};
+
+const OAUTH_TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+const JWT_BEARER_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const JWT_LIFETIME: Duration = Duration::from_secs(3600);
+
+#[derive(Debug, Serialize)]
+struct Claims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'static str,
+    exp: u64,
+    iat: u64,
+}
+
+impl<'a> Claims<'a> {
+    fn new(client_email: &'a str, scope: &'a str, now: Timestamp) -> Result<Self> {
+        let iat = u64::try_from(now.as_second())
+            .map_err(|_| Error::unexpected("service account JWT timestamp is invalid"))?;
+        let exp = iat
+            .checked_add(JWT_LIFETIME.as_secs())
+            .ok_or_else(|| Error::unexpected("service account JWT timestamp is invalid"))?;
+        Ok(Self {
+            iss: client_email,
+            scope,
+            aud: OAUTH_TOKEN_ENDPOINT,
+            exp,
+            iat,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct JwtHeader {
+    alg: &'static str,
+    typ: &'static str,
+}
+
+impl JwtHeader {
+    fn rs256() -> Self {
+        Self {
+            alg: "RS256",
+            typ: "JWT",
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+#[derive(Deserialize)]
+struct OAuthErrorResponse {
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Clone)]
+enum Source {
+    ServiceAccount(ServiceAccount),
+    Provider(Arc<dyn ProvideCredentialDyn<Credential = Credential>>),
+}
+
+/// Exchanges a service-account credential for an OAuth access token.
+///
+/// The provider returns a token-only [`Credential`] with a non-optional absolute
+/// expiration and preserves the source service account email as signer identity.
+/// This makes service-account JSON loaded by providers such as
+/// [`super::FileCredentialProvider`] usable as the source of a Google credential
+/// granter without requiring the host application to implement the JWT bearer
+/// exchange.
+///
+/// The provider performs an OAuth exchange on every call. Cache and refresh
+/// behavior remains owned by the outer [`reqsign_core::Signer`] or
+/// [`reqsign_core::Granter`]. It is not inserted into the default credential
+/// provider chain.
+///
+/// # Example
+///
+/// ```no_run
+/// use reqsign_core::{Context, Granter};
+/// use reqsign_google::{
+///     CredentialAccessBoundaryGrant, CredentialAccessBoundaryPermissions,
+///     FileCredentialProvider, ServerSideCredentialAccessBoundaryGranter,
+///     ServiceAccountTokenCredentialProvider,
+/// };
+///
+/// # async fn example(context: Context) -> reqsign_core::Result<()> {
+/// let source = ServiceAccountTokenCredentialProvider::from_provider(
+///     FileCredentialProvider::new("/path/to/service-account.json"),
+/// );
+/// let grant = CredentialAccessBoundaryGrant::for_object_prefix(
+///     "example-bucket",
+///     "customer-a/",
+///     CredentialAccessBoundaryPermissions::OBJECT_VIEWER,
+/// );
+/// let credential = Granter::new(
+///     context,
+///     source,
+///     ServerSideCredentialAccessBoundaryGranter::new(grant),
+/// )
+/// .grant(None)
+/// .await?;
+/// # let _ = credential;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct ServiceAccountTokenCredentialProvider {
+    source: Source,
+    scope: Option<String>,
+}
+
+impl Debug for ServiceAccountTokenCredentialProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServiceAccountTokenCredentialProvider")
+            .field("scope", &self.scope)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ServiceAccountTokenCredentialProvider {
+    /// Create a provider bound to one service account.
+    pub fn new(service_account: ServiceAccount) -> Self {
+        Self {
+            source: Source::ServiceAccount(service_account),
+            scope: None,
+        }
+    }
+
+    /// Create a provider that loads its service account from another provider.
+    ///
+    /// `None` from the source provider is preserved. A returned credential must
+    /// contain a valid service account; other credential variants are rejected
+    /// before the OAuth request is sent.
+    pub fn from_provider(
+        provider: impl ProvideCredential<Credential = Credential> + 'static,
+    ) -> Self {
+        Self {
+            source: Source::Provider(Arc::new(provider)),
+            scope: None,
+        }
+    }
+
+    /// Set the OAuth scope.
+    ///
+    /// This value takes precedence over `GOOGLE_SCOPE`. When neither is set,
+    /// the Google Cloud platform scope is used.
+    pub fn with_scope(mut self, scope: impl Into<String>) -> Self {
+        self.scope = Some(scope.into());
+        self
+    }
+
+    async fn service_account(&self, ctx: &Context) -> Result<Option<ServiceAccount>> {
+        let service_account = match &self.source {
+            Source::ServiceAccount(service_account) => service_account.clone(),
+            Source::Provider(provider) => {
+                let credential = match provider.provide_credential_dyn(ctx).await? {
+                    Some(credential) => credential,
+                    None => return Ok(None),
+                };
+                credential.service_account.ok_or_else(|| {
+                    Error::credential_invalid(
+                        "service account OAuth token provider requires a service-account credential",
+                    )
+                })?
+            }
+        };
+
+        if !service_account.is_valid() {
+            return Err(Error::credential_invalid(
+                "service account OAuth token provider requires a client email and private key",
+            ));
+        }
+        Ok(Some(service_account))
+    }
+}
+
+impl ProvideCredential for ServiceAccountTokenCredentialProvider {
+    type Credential = Credential;
+
+    async fn provide_credential(&self, ctx: &Context) -> Result<Option<Self::Credential>> {
+        let Some(service_account) = self.service_account(ctx).await? else {
+            return Ok(None);
+        };
+        let scope = resolve_scope(ctx, self.scope.as_deref());
+        let token = exchange_service_account_token(ctx, &service_account, &scope).await?;
+        Ok(Some(
+            Credential::with_token(token).with_signer_email(service_account.client_email),
+        ))
+    }
+}
+
+pub(crate) fn resolve_scope(ctx: &Context, scope: Option<&str>) -> String {
+    scope
+        .map(ToOwned::to_owned)
+        .or_else(|| ctx.env_var(GOOGLE_SCOPE))
+        .unwrap_or_else(|| DEFAULT_SCOPE.to_string())
+}
+
+pub(crate) async fn exchange_service_account_token(
+    ctx: &Context,
+    service_account: &ServiceAccount,
+    scope: &str,
+) -> Result<Token> {
+    if !service_account.is_valid() {
+        return Err(Error::credential_invalid(
+            "service account OAuth exchange requires a client email and private key",
+        ));
+    }
+
+    debug!("exchanging service account for token with scope: {scope}");
+    let request = build_token_request(service_account, scope, Timestamp::now())?;
+    let request_started_at = Timestamp::now();
+    let response = ctx.http_send(request).await.map_err(|err| {
+        Error::new(err.kind(), "service account OAuth token request failed")
+            .set_retryable(err.is_retryable())
+    })?;
+    let completed_at = Timestamp::now();
+
+    if response.status() != http::StatusCode::OK {
+        return Err(oauth_error(response.status(), response.body()));
+    }
+    let token = parse_token_response(response.body(), request_started_at)?;
+    validate_token(&token, completed_at)?;
+    Ok(token)
+}
+
+fn build_token_request(
+    service_account: &ServiceAccount,
+    scope: &str,
+    now: Timestamp,
+) -> Result<http::Request<bytes::Bytes>> {
+    let jwt = reqsign_core::jwt::encode_rs256_pem(
+        &JwtHeader::rs256(),
+        &Claims::new(&service_account.client_email, scope, now)?,
+        service_account.private_key.as_bytes(),
+    )?;
+    let body = Serializer::new(String::new())
+        .append_pair("grant_type", JWT_BEARER_GRANT_TYPE)
+        .append_pair("assertion", &jwt)
+        .finish();
+
+    http::Request::builder()
+        .method(http::Method::POST)
+        .uri(OAUTH_TOKEN_ENDPOINT)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(body.into_bytes().into())
+        .map_err(|err| {
+            Error::unexpected("failed to build service account OAuth token request")
+                .with_source(err)
+        })
+}
+
+fn parse_token_response(body: &[u8], request_started_at: Timestamp) -> Result<Token> {
+    let response: TokenResponse = serde_json::from_slice(body)
+        .map_err(|_| Error::unexpected("failed to parse service account OAuth token response"))?;
+    if response.access_token.is_empty() || response.expires_in == 0 {
+        return Err(Error::unexpected(
+            "service account OAuth token response is malformed",
+        ));
+    }
+    let expires_at =
+        checked_expiration(request_started_at, Duration::from_secs(response.expires_in))?;
+    Ok(Token {
+        access_token: response.access_token,
+        expires_at: Some(expires_at),
+    })
+}
+
+fn validate_token(token: &Token, completed_at: Timestamp) -> Result<()> {
+    let required_until = checked_expiration(completed_at, TOKEN_OPERATION_HEADROOM)?;
+    if !token.is_valid_at(required_until) {
+        return Err(Error::credential_invalid(
+            "service account OAuth token is not valid long enough for Google signing",
+        ));
+    }
+    Ok(())
+}
+
+fn checked_expiration(started_at: Timestamp, expires_in: Duration) -> Result<Timestamp> {
+    let expires_in_seconds = i64::try_from(expires_in.as_secs())
+        .map_err(|_| Error::unexpected("service account OAuth token expiration is invalid"))?;
+    let expiration_second = started_at
+        .as_second()
+        .checked_add(expires_in_seconds)
+        .ok_or_else(|| Error::unexpected("service account OAuth token expiration is invalid"))?;
+    Timestamp::from_second(expiration_second)
+        .map_err(|_| Error::unexpected("service account OAuth token expiration is invalid"))
+}
+
+fn oauth_error(status: http::StatusCode, body: &[u8]) -> Error {
+    let error_code = serde_json::from_slice::<OAuthErrorResponse>(body)
+        .ok()
+        .and_then(|response| response.error);
+    let recognized_code = match error_code.as_deref() {
+        Some(
+            code @ ("invalid_grant"
+            | "invalid_request"
+            | "invalid_scope"
+            | "unsupported_grant_type"
+            | "unauthorized_client"
+            | "invalid_client"
+            | "access_denied"
+            | "temporarily_unavailable"),
+        ) => Some(code),
+        _ => None,
+    };
+
+    let mut error = match recognized_code {
+        Some("invalid_grant" | "invalid_client") => Error::credential_invalid(
+            "service account OAuth token exchange rejected the source credential",
+        ),
+        Some("invalid_request" | "invalid_scope" | "unsupported_grant_type") => {
+            Error::request_invalid("service account OAuth token exchange rejected the request")
+        }
+        Some("unauthorized_client" | "access_denied") => {
+            Error::permission_denied("service account OAuth token exchange was denied")
+        }
+        Some("temporarily_unavailable") => {
+            Error::unexpected("service account OAuth token exchange is temporarily unavailable")
+                .set_retryable(true)
+        }
+        _ if status == http::StatusCode::UNAUTHORIZED => Error::credential_invalid(
+            "service account OAuth token exchange rejected the source credential",
+        ),
+        _ if status == http::StatusCode::FORBIDDEN => {
+            Error::permission_denied("service account OAuth token exchange was denied")
+        }
+        _ if status == http::StatusCode::TOO_MANY_REQUESTS => {
+            Error::rate_limited("service account OAuth token exchange was rate limited")
+        }
+        _ => Error::unexpected("service account OAuth token exchange failed")
+            .set_retryable(status.is_server_error()),
+    }
+    .with_context(format!("oauth_status: {}", status.as_u16()));
+
+    if let Some(code) = recognized_code {
+        error = error.with_context(format!("oauth_error: {code}"));
+    }
+    if error.kind() == ErrorKind::Unexpected && status.is_server_error() {
+        error = error.set_retryable(true);
+    }
+    error
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap, VecDeque};
+    use std::sync::{Arc, Mutex};
+
+    use bytes::Bytes;
+    use http::{HeaderMap, Method};
+    use reqsign_core::hash::base64_decode;
+    use reqsign_core::{FileRead, Granter, HttpSend, SignRequest, StaticEnv, time::Timestamp};
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs8::{EncodePrivateKey, LineEnding};
+    use rsa::rand_core::OsRng;
+    use serde_json::Value;
+
+    use crate::{
+        CredentialAccessBoundaryGrant, CredentialAccessBoundaryPermissions,
+        DefaultCredentialProvider, FileCredentialProvider, RequestSigner,
+        ServerSideCredentialAccessBoundaryGranter, StaticCredentialProvider,
+    };
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct CapturedRequest {
+        method: Method,
+        uri: String,
+        headers: HeaderMap,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct MockHttpSend {
+        responses: Arc<Mutex<VecDeque<http::Response<Bytes>>>>,
+        requests: Arc<Mutex<Vec<CapturedRequest>>>,
+    }
+
+    impl MockHttpSend {
+        fn new(responses: impl IntoIterator<Item = http::Response<Bytes>>) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn requests(&self) -> std::sync::MutexGuard<'_, Vec<CapturedRequest>> {
+            self.requests.lock().expect("lock must not be poisoned")
+        }
+    }
+
+    impl HttpSend for MockHttpSend {
+        async fn http_send(&self, request: http::Request<Bytes>) -> Result<http::Response<Bytes>> {
+            let (parts, body) = request.into_parts();
+            self.requests
+                .lock()
+                .expect("lock must not be poisoned")
+                .push(CapturedRequest {
+                    method: parts.method,
+                    uri: parts.uri.to_string(),
+                    headers: parts.headers,
+                    body: body.to_vec(),
+                });
+            self.responses
+                .lock()
+                .expect("lock must not be poisoned")
+                .pop_front()
+                .ok_or_else(|| Error::unexpected("mock HTTP response is missing"))
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct FixedFileRead {
+        content: Arc<Vec<u8>>,
+    }
+
+    impl FixedFileRead {
+        fn new(content: impl Into<Vec<u8>>) -> Self {
+            Self {
+                content: Arc::new(content.into()),
+            }
+        }
+    }
+
+    impl FileRead for FixedFileRead {
+        async fn file_read(&self, _path: &str) -> Result<Vec<u8>> {
+            Ok(self.content.as_ref().clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct FixedProvider {
+        credential: Option<Credential>,
+    }
+
+    impl ProvideCredential for FixedProvider {
+        type Credential = Credential;
+
+        async fn provide_credential(&self, _ctx: &Context) -> Result<Option<Self::Credential>> {
+            Ok(self.credential.clone())
+        }
+    }
+
+    fn service_account() -> ServiceAccount {
+        let key = RsaPrivateKey::new(&mut OsRng, 1024).expect("test RSA key must generate");
+        let private_key = key
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("test RSA key must encode")
+            .to_string();
+        ServiceAccount {
+            private_key,
+            client_email: "provider@example.iam.gserviceaccount.com".to_string(),
+        }
+    }
+
+    fn service_account_json(service_account: &ServiceAccount) -> String {
+        serde_json::json!({
+            "type": "service_account",
+            "private_key": service_account.private_key,
+            "client_email": service_account.client_email,
+        })
+        .to_string()
+    }
+
+    fn response(status: http::StatusCode, body: impl Into<Bytes>) -> http::Response<Bytes> {
+        http::Response::builder()
+            .status(status)
+            .body(body.into())
+            .expect("response must build")
+    }
+
+    fn oauth_success(access_token: &str, expires_in: u64) -> http::Response<Bytes> {
+        response(
+            http::StatusCode::OK,
+            serde_json::to_vec(&serde_json::json!({
+                "access_token": access_token,
+                "expires_in": expires_in,
+                "token_type": "Bearer",
+            }))
+            .expect("response JSON must serialize"),
+        )
+    }
+
+    fn cab_success(access_token: &str, expires_in: u64) -> http::Response<Bytes> {
+        response(
+            http::StatusCode::OK,
+            serde_json::to_vec(&serde_json::json!({
+                "access_token": access_token,
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+                "expires_in": expires_in,
+            }))
+            .expect("response JSON must serialize"),
+        )
+    }
+
+    fn form_fields(body: &[u8]) -> BTreeMap<String, String> {
+        form_urlencoded::parse(body).into_owned().collect()
+    }
+
+    fn decode_jwt_json(segment: &str) -> Value {
+        let mut standard = segment.replace('-', "+").replace('_', "/");
+        while standard.len() % 4 != 0 {
+            standard.push('=');
+        }
+        serde_json::from_slice(&base64_decode(&standard).expect("JWT segment must decode"))
+            .expect("JWT segment must contain JSON")
+    }
+
+    #[tokio::test]
+    async fn exchanges_service_account_with_exact_request_shape() -> Result<()> {
+        let http = MockHttpSend::new([oauth_success("source-token", 3600)]);
+        let service_account = service_account();
+        let provider = ServiceAccountTokenCredentialProvider::new(service_account.clone())
+            .with_scope("scope-a scope-b");
+        let output = provider
+            .provide_credential(&Context::new().with_http_send(http.clone()))
+            .await?
+            .expect("credential must be returned");
+
+        assert!(output.service_account.is_none());
+        assert_eq!(
+            output.signer_email.as_deref(),
+            Some(service_account.client_email.as_str())
+        );
+        let token = output.token.expect("token must be present");
+        assert_eq!(token.access_token, "source-token");
+        assert!(token.expires_at.is_some());
+
+        let requests = http.requests();
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert_eq!(request.method, Method::POST);
+        assert_eq!(request.uri, OAUTH_TOKEN_ENDPOINT);
+        assert_eq!(
+            request.headers[CONTENT_TYPE],
+            "application/x-www-form-urlencoded"
+        );
+
+        let fields = form_fields(&request.body);
+        assert_eq!(fields["grant_type"], JWT_BEARER_GRANT_TYPE);
+        let segments = fields["assertion"].split('.').collect::<Vec<_>>();
+        assert_eq!(segments.len(), 3);
+        assert_eq!(
+            decode_jwt_json(segments[0]),
+            serde_json::json!({"alg": "RS256", "typ": "JWT"})
+        );
+        let claims = decode_jwt_json(segments[1]);
+        assert_eq!(claims["iss"], service_account.client_email);
+        assert_eq!(claims["scope"], "scope-a scope-b");
+        assert_eq!(claims["aud"], OAUTH_TOKEN_ENDPOINT);
+        assert_eq!(
+            claims["exp"].as_u64().expect("exp must be an integer")
+                - claims["iat"].as_u64().expect("iat must be an integer"),
+            JWT_LIFETIME.as_secs()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scope_precedence_is_explicit_then_environment_then_default() {
+        let ctx = Context::new().with_env(StaticEnv {
+            home_dir: None,
+            envs: HashMap::from([(GOOGLE_SCOPE.to_string(), "environment-scope".to_string())]),
+        });
+        assert_eq!(
+            resolve_scope(&ctx, Some("explicit-scope")),
+            "explicit-scope"
+        );
+        assert_eq!(resolve_scope(&ctx, None), "environment-scope");
+        assert_eq!(resolve_scope(&Context::new(), None), DEFAULT_SCOPE);
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_source_before_oauth_io_and_preserves_none() -> Result<()> {
+        let http = MockHttpSend::default();
+        let ctx = Context::new().with_http_send(http.clone());
+
+        let missing = ServiceAccountTokenCredentialProvider::from_provider(FixedProvider {
+            credential: None,
+        });
+        assert!(missing.provide_credential(&ctx).await?.is_none());
+
+        let wrong_variant = ServiceAccountTokenCredentialProvider::from_provider(FixedProvider {
+            credential: Some(Credential::with_token(Token {
+                access_token: "source-token".to_string(),
+                expires_at: None,
+            })),
+        });
+        let err = wrong_variant
+            .provide_credential(&ctx)
+            .await
+            .expect_err("token-only source must be rejected");
+        assert_eq!(err.kind(), ErrorKind::CredentialInvalid);
+
+        let invalid_key = ServiceAccountTokenCredentialProvider::new(ServiceAccount {
+            private_key: "private-key-secret".to_string(),
+            client_email: "provider@example.iam.gserviceaccount.com".to_string(),
+        });
+        let err = invalid_key
+            .provide_credential(&ctx)
+            .await
+            .expect_err("invalid private key must be rejected");
+        assert_eq!(err.kind(), ErrorKind::CredentialInvalid);
+        assert_eq!(http.requests().len(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn accepts_file_and_default_service_account_sources() -> Result<()> {
+        let service_account = service_account();
+        let content = service_account_json(&service_account).into_bytes();
+
+        let file_http = MockHttpSend::new([oauth_success("file-token", 3600)]);
+        let file_context = Context::new()
+            .with_file_read(FixedFileRead::new(content.clone()))
+            .with_http_send(file_http);
+        let file_output = ServiceAccountTokenCredentialProvider::from_provider(
+            FileCredentialProvider::new("/service-account.json"),
+        )
+        .provide_credential(&file_context)
+        .await?
+        .expect("file source must return a credential");
+        assert_eq!(
+            file_output
+                .token
+                .expect("file source token must be present")
+                .access_token,
+            "file-token"
+        );
+
+        let default_http = MockHttpSend::new([oauth_success("default-token", 3600)]);
+        let default_context = Context::new()
+            .with_file_read(FixedFileRead::new(content))
+            .with_http_send(default_http)
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::from([(
+                    crate::constants::GOOGLE_APPLICATION_CREDENTIALS.to_string(),
+                    "/service-account.json".to_string(),
+                )]),
+            });
+        let default_output =
+            ServiceAccountTokenCredentialProvider::from_provider(DefaultCredentialProvider::new())
+                .provide_credential(&default_context)
+                .await?
+                .expect("default source must return a credential");
+        assert_eq!(
+            default_output
+                .token
+                .expect("default source token must be present")
+                .access_token,
+            "default-token"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_token_that_is_too_short_after_oauth_io() {
+        let http = MockHttpSend::new([oauth_success("short-token", 5)]);
+        let err = ServiceAccountTokenCredentialProvider::new(service_account())
+            .provide_credential(&Context::new().with_http_send(http.clone()))
+            .await
+            .expect_err("short OAuth token must be rejected");
+
+        assert_eq!(err.kind(), ErrorKind::CredentialInvalid);
+        assert_eq!(http.requests().len(), 1);
+    }
+
+    #[test]
+    fn expiration_is_anchored_and_checked_without_panicking() {
+        let started_at: Timestamp = "2030-01-01T00:00:00Z"
+            .parse()
+            .expect("timestamp must parse");
+        let token = parse_token_response(
+            br#"{"access_token":"source-token","expires_in":3600}"#,
+            started_at,
+        )
+        .expect("response must parse");
+        assert_eq!(
+            token.expires_at,
+            Some(
+                "2030-01-01T01:00:00Z"
+                    .parse()
+                    .expect("timestamp must parse")
+            )
+        );
+
+        let near_limit: Timestamp = "9999-12-30T21:59:59Z"
+            .parse()
+            .expect("timestamp must parse");
+        let err = parse_token_response(
+            br#"{"access_token":"source-token","expires_in":2}"#,
+            near_limit,
+        )
+        .expect_err("overflow must be rejected");
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+
+        for malformed in [
+            br#"{"access_token":"source-token"}"#.as_slice(),
+            br#"{"access_token":"","expires_in":3600}"#.as_slice(),
+            br#"{"access_token":"source-token","expires_in":0}"#.as_slice(),
+        ] {
+            assert!(parse_token_response(malformed, started_at).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn redacts_provider_debug_and_oauth_errors() {
+        let service_account = service_account();
+        let source_json = service_account_json(&service_account);
+        let provider = ServiceAccountTokenCredentialProvider::from_provider(
+            StaticCredentialProvider::new(source_json),
+        );
+        let debug = format!("{provider:?}");
+        assert!(!debug.contains(&service_account.private_key));
+        assert!(!debug.contains("BEGIN PRIVATE KEY"));
+
+        let body = br#"{
+            "error":"invalid_grant",
+            "error_description":"private-key-secret assertion-secret access-token-secret"
+        }"#;
+        let http = MockHttpSend::new([response(http::StatusCode::BAD_REQUEST, body.as_slice())]);
+        let err = provider
+            .provide_credential(&Context::new().with_http_send(http))
+            .await
+            .expect_err("OAuth error must be returned");
+        assert_eq!(err.kind(), ErrorKind::CredentialInvalid);
+        let rendered = format!("{err:?}");
+        assert!(rendered.contains("oauth_error: invalid_grant"));
+        assert!(!rendered.contains("private-key-secret"));
+        assert!(!rendered.contains("assertion-secret"));
+        assert!(!rendered.contains("access-token-secret"));
+    }
+
+    #[tokio::test]
+    async fn composes_static_service_account_with_server_side_cab() -> Result<()> {
+        let http = MockHttpSend::new([
+            oauth_success("source-token", 3600),
+            cab_success("downscoped-token", 600),
+        ]);
+        let service_account = service_account();
+        let source = ServiceAccountTokenCredentialProvider::from_provider(
+            StaticCredentialProvider::new(service_account_json(&service_account)),
+        );
+        let grant = CredentialAccessBoundaryGrant::for_object_prefix(
+            "example-bucket",
+            "customer-a/",
+            CredentialAccessBoundaryPermissions::OBJECT_VIEWER,
+        );
+        let output = Granter::new(
+            Context::new().with_http_send(http.clone()),
+            source,
+            ServerSideCredentialAccessBoundaryGranter::new(grant),
+        )
+        .grant(None)
+        .await?;
+
+        assert!(output.service_account.is_none());
+        let token = output.token.expect("downscoped token must be present");
+        assert_eq!(token.access_token, "downscoped-token");
+        assert!(token.expires_at.is_some());
+
+        let requests = http.requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].uri, OAUTH_TOKEN_ENDPOINT);
+        assert_eq!(requests[1].uri, "https://sts.googleapis.com/v1/token");
+        assert_eq!(
+            form_fields(&requests[1].body)["subject_token"],
+            "source-token"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn request_signer_uses_shared_service_account_exchange() -> Result<()> {
+        let http = MockHttpSend::new([oauth_success("source-token", 3600)]);
+        let credential = Credential::with_service_account(service_account());
+        let mut request = http::Request::get("https://storage.googleapis.com/bucket/object")
+            .body(())?
+            .into_parts()
+            .0;
+
+        RequestSigner::new("storage")
+            .sign_request(
+                &Context::new().with_http_send(http.clone()),
+                &mut request,
+                Some(&credential),
+                None,
+            )
+            .await?;
+
+        assert_eq!(
+            request.headers[http::header::AUTHORIZATION],
+            "Bearer source-token"
+        );
+        assert_eq!(http.requests().len(), 1);
+        assert_eq!(http.requests()[0].uri, OAUTH_TOKEN_ENDPOINT);
+        Ok(())
+    }
+}

--- a/services/google/src/sign_request.rs
+++ b/services/google/src/sign_request.rs
@@ -31,7 +31,7 @@ use reqsign_core::{
 
 use crate::constants::{GOOG_QUERY_ENCODE_SET, GOOG_URI_ENCODE_SET, TOKEN_OPERATION_HEADROOM};
 use crate::credential::{Credential, ServiceAccount, Token};
-use crate::provide_credential::{exchange_service_account_token, resolve_scope};
+use crate::provide_credential::exchange_service_account_token;
 
 /// RequestSigner for Google service requests.
 #[derive(Debug)]
@@ -95,8 +95,7 @@ impl RequestSigner {
     /// This method is used internally when a token is needed but only a service account
     /// is available. It creates a JWT and exchanges it for an OAuth2 access token.
     async fn exchange_token(&self, ctx: &Context, sa: &ServiceAccount) -> Result<Token> {
-        let scope = resolve_scope(ctx, self.scope.as_deref());
-        exchange_service_account_token(ctx, sa, &scope).await
+        exchange_service_account_token(ctx, sa, self.scope.as_deref()).await
     }
 
     fn build_token_auth(

--- a/services/google/src/sign_request.rs
+++ b/services/google/src/sign_request.rs
@@ -29,9 +29,59 @@ use reqsign_core::{
     Context, Result, SignRequest, SigningCredential, SigningRequest, hash::hex_sha256, time::*,
 };
 
-use crate::constants::{GOOG_QUERY_ENCODE_SET, GOOG_URI_ENCODE_SET, TOKEN_OPERATION_HEADROOM};
+use crate::constants::{
+    DEFAULT_SCOPE, GOOG_QUERY_ENCODE_SET, GOOG_URI_ENCODE_SET, GOOGLE_SCOPE,
+    TOKEN_OPERATION_HEADROOM,
+};
 use crate::credential::{Credential, ServiceAccount, Token};
-use crate::provide_credential::exchange_service_account_token;
+
+/// Claims is used to build JWT for Google Cloud.
+#[derive(Debug, Serialize)]
+struct Claims {
+    iss: String,
+    scope: String,
+    aud: String,
+    exp: u64,
+    iat: u64,
+}
+
+impl Claims {
+    fn new(client_email: &str, scope: &str) -> Self {
+        let current = Timestamp::now().as_second() as u64;
+
+        Claims {
+            iss: client_email.to_string(),
+            scope: scope.to_string(),
+            aud: "https://oauth2.googleapis.com/token".to_string(),
+            exp: current + 3600,
+            iat: current,
+        }
+    }
+}
+
+/// Header is used to build RS256 JWT for Google Cloud OAuth2.
+#[derive(Debug, Serialize)]
+struct JwtHeader {
+    alg: &'static str,
+    typ: &'static str,
+}
+
+impl JwtHeader {
+    fn rs256() -> Self {
+        Self {
+            alg: "RS256",
+            typ: "JWT",
+        }
+    }
+}
+
+/// OAuth2 token response.
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    expires_in: Option<u64>,
+}
 
 /// RequestSigner for Google service requests.
 #[derive(Debug)]
@@ -95,7 +145,53 @@ impl RequestSigner {
     /// This method is used internally when a token is needed but only a service account
     /// is available. It creates a JWT and exchanges it for an OAuth2 access token.
     async fn exchange_token(&self, ctx: &Context, sa: &ServiceAccount) -> Result<Token> {
-        exchange_service_account_token(ctx, sa, self.scope.as_deref()).await
+        let scope = self
+            .scope
+            .clone()
+            .or_else(|| ctx.env_var(GOOGLE_SCOPE))
+            .unwrap_or_else(|| DEFAULT_SCOPE.to_string());
+
+        debug!("exchanging service account for token with scope: {scope}");
+
+        let jwt = reqsign_core::jwt::encode_rs256_pem(
+            &JwtHeader::rs256(),
+            &Claims::new(&sa.client_email, &scope),
+            sa.private_key.as_bytes(),
+        )?;
+
+        // Exchange JWT for access token
+        let body =
+            format!("grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion={jwt}");
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://oauth2.googleapis.com/token")
+            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(body.into_bytes().into())
+            .map_err(|e| {
+                reqsign_core::Error::unexpected("failed to build HTTP request").with_source(e)
+            })?;
+
+        let resp = ctx.http_send(req).await?;
+
+        if resp.status() != http::StatusCode::OK {
+            let body = String::from_utf8_lossy(resp.body());
+            return Err(reqsign_core::Error::unexpected(format!(
+                "exchange token failed: {body}"
+            )));
+        }
+
+        let token_resp: TokenResponse = serde_json::from_slice(resp.body()).map_err(|e| {
+            reqsign_core::Error::unexpected("failed to parse token response").with_source(e)
+        })?;
+
+        let expires_at = token_resp
+            .expires_in
+            .map(|expires_in| Timestamp::now() + Duration::from_secs(expires_in));
+
+        Ok(Token {
+            access_token: token_resp.access_token,
+            expires_at,
+        })
     }
 
     fn build_token_auth(
@@ -594,6 +690,7 @@ mod tests {
     use bytes::Bytes;
     use http::header;
     use reqsign_core::{ErrorKind, HttpSend, ProvideCredential, Signer};
+    use rsa::pkcs8::{EncodePrivateKey, LineEnding};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -668,6 +765,20 @@ mod tests {
             Ok(http::Response::builder()
                 .status(http::StatusCode::OK)
                 .body(body.as_slice().into())
+                .expect("response must build"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct OAuthTokenHttpSend;
+
+    impl HttpSend for OAuthTokenHttpSend {
+        async fn http_send(&self, req: http::Request<Bytes>) -> Result<http::Response<Bytes>> {
+            assert_eq!(req.method(), http::Method::POST);
+            assert_eq!(req.uri(), "https://oauth2.googleapis.com/token");
+            Ok(http::Response::builder()
+                .status(http::StatusCode::OK)
+                .body(Bytes::from_static(br#"{"access_token":"legacy-token"}"#))
                 .expect("response must build"))
         }
     }
@@ -947,6 +1058,35 @@ mod tests {
             parts.headers[header::AUTHORIZATION],
             "Bearer test-access-token"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn service_account_exchange_preserves_optional_expiration_response() -> Result<()> {
+        let private_key = rsa::RsaPrivateKey::new(&mut OsRng, 1024)
+            .expect("private key must generate")
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("private key must encode")
+            .to_string();
+        let credential = Credential::with_service_account(ServiceAccount {
+            private_key,
+            client_email: "signer@example.iam.gserviceaccount.com".to_string(),
+        });
+        let mut parts = http::Request::get("https://storage.googleapis.com/bucket/object")
+            .body(())?
+            .into_parts()
+            .0;
+
+        RequestSigner::new("storage")
+            .sign_request(
+                &Context::new().with_http_send(OAuthTokenHttpSend),
+                &mut parts,
+                Some(&credential),
+                None,
+            )
+            .await?;
+
+        assert_eq!(parts.headers[header::AUTHORIZATION], "Bearer legacy-token");
         Ok(())
     }
 

--- a/services/google/src/sign_request.rs
+++ b/services/google/src/sign_request.rs
@@ -29,59 +29,9 @@ use reqsign_core::{
     Context, Result, SignRequest, SigningCredential, SigningRequest, hash::hex_sha256, time::*,
 };
 
-use crate::constants::{
-    DEFAULT_SCOPE, GOOG_QUERY_ENCODE_SET, GOOG_URI_ENCODE_SET, GOOGLE_SCOPE,
-    TOKEN_OPERATION_HEADROOM,
-};
+use crate::constants::{GOOG_QUERY_ENCODE_SET, GOOG_URI_ENCODE_SET, TOKEN_OPERATION_HEADROOM};
 use crate::credential::{Credential, ServiceAccount, Token};
-
-/// Claims is used to build JWT for Google Cloud.
-#[derive(Debug, Serialize)]
-struct Claims {
-    iss: String,
-    scope: String,
-    aud: String,
-    exp: u64,
-    iat: u64,
-}
-
-impl Claims {
-    fn new(client_email: &str, scope: &str) -> Self {
-        let current = Timestamp::now().as_second() as u64;
-
-        Claims {
-            iss: client_email.to_string(),
-            scope: scope.to_string(),
-            aud: "https://oauth2.googleapis.com/token".to_string(),
-            exp: current + 3600,
-            iat: current,
-        }
-    }
-}
-
-/// Header is used to build RS256 JWT for Google Cloud OAuth2.
-#[derive(Debug, Serialize)]
-struct JwtHeader {
-    alg: &'static str,
-    typ: &'static str,
-}
-
-impl JwtHeader {
-    fn rs256() -> Self {
-        Self {
-            alg: "RS256",
-            typ: "JWT",
-        }
-    }
-}
-
-/// OAuth2 token response.
-#[derive(Deserialize)]
-struct TokenResponse {
-    access_token: String,
-    #[serde(default)]
-    expires_in: Option<u64>,
-}
+use crate::provide_credential::{exchange_service_account_token, resolve_scope};
 
 /// RequestSigner for Google service requests.
 #[derive(Debug)]
@@ -145,53 +95,8 @@ impl RequestSigner {
     /// This method is used internally when a token is needed but only a service account
     /// is available. It creates a JWT and exchanges it for an OAuth2 access token.
     async fn exchange_token(&self, ctx: &Context, sa: &ServiceAccount) -> Result<Token> {
-        let scope = self
-            .scope
-            .clone()
-            .or_else(|| ctx.env_var(GOOGLE_SCOPE))
-            .unwrap_or_else(|| DEFAULT_SCOPE.to_string());
-
-        debug!("exchanging service account for token with scope: {scope}");
-
-        let jwt = reqsign_core::jwt::encode_rs256_pem(
-            &JwtHeader::rs256(),
-            &Claims::new(&sa.client_email, &scope),
-            sa.private_key.as_bytes(),
-        )?;
-
-        // Exchange JWT for access token
-        let body =
-            format!("grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion={jwt}");
-        let req = http::Request::builder()
-            .method(http::Method::POST)
-            .uri("https://oauth2.googleapis.com/token")
-            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
-            .body(body.into_bytes().into())
-            .map_err(|e| {
-                reqsign_core::Error::unexpected("failed to build HTTP request").with_source(e)
-            })?;
-
-        let resp = ctx.http_send(req).await?;
-
-        if resp.status() != http::StatusCode::OK {
-            let body = String::from_utf8_lossy(resp.body());
-            return Err(reqsign_core::Error::unexpected(format!(
-                "exchange token failed: {body}"
-            )));
-        }
-
-        let token_resp: TokenResponse = serde_json::from_slice(resp.body()).map_err(|e| {
-            reqsign_core::Error::unexpected("failed to parse token response").with_source(e)
-        })?;
-
-        let expires_at = token_resp
-            .expires_in
-            .map(|expires_in| Timestamp::now() + Duration::from_secs(expires_in));
-
-        Ok(Token {
-            access_token: token_resp.access_token,
-            expires_at,
-        })
+        let scope = resolve_scope(ctx, self.scope.as_deref());
+        exchange_service_account_token(ctx, sa, &scope).await
     }
 
     fn build_token_auth(

--- a/services/google/tests/README.md
+++ b/services/google/tests/README.md
@@ -36,13 +36,16 @@ Tests for request signing functionality:
 - `REQSIGN_GOOGLE_TEST_VM_METADATA`: Set to `on` to enable VmMetadataCredentialProvider tests (GCP VMs only)
 - `REQSIGN_GOOGLE_TEST_VM_METADATA_MOCK`: Set to `on` to enable VmMetadataCredentialProvider tests with the local mock server
 - `REQSIGN_GOOGLE_TEST_CAB`: Set to `on` to enable the live CAB interoperability test
+- `REQSIGN_GOOGLE_TEST_SERVICE_ACCOUNT_TOKEN`: Set to `on` to enable the live service-account token provider test
 
 ### Google Cloud Configuration
 - `GOOGLE_APPLICATION_CREDENTIALS`: Path to credential JSON file (supports all credential types)
 - `REQSIGN_GOOGLE_CREDENTIAL`: Base64-encoded service account JSON (for StaticCredentialProvider)
 - `REQSIGN_GOOGLE_CLOUD_STORAGE_SCOPE`: OAuth2 scope for GCS (e.g., `https://www.googleapis.com/auth/devstorage.read_write`)
 - `REQSIGN_GOOGLE_CLOUD_STORAGE_URL`: GCS bucket URL (e.g., `https://storage.googleapis.com/storage/v1/b/your-bucket`)
-- `REQSIGN_GOOGLE_CAB_BUCKET`: Bucket used by the CAB live tests
+- `REQSIGN_GOOGLE_CAB_SOURCE_TOKEN`: Service-account OAuth access token with the Cloud Platform scope
+- `REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT`: Absolute RFC 3339 expiration of the source token
+- `REQSIGN_GOOGLE_CAB_BUCKET`: Bucket used by the client-issued CAB live test
 - `REQSIGN_GOOGLE_CAB_OBJECT_PREFIX`: Non-empty object prefix used by the CAB list test
 - `GOOGLE_IMPERSONATED_CREDENTIALS`: Path to impersonated service account credential file
 - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`: Workload Identity Provider ID (for GitHub Actions)
@@ -71,11 +74,11 @@ REQSIGN_GOOGLE_TEST_DEFAULT=on cargo test test_default_credential_provider
 # Run all credential provider tests
 cargo test credential_providers::
 
-# Run the live server-side CAB and Cloud Storage interoperability test
-REQSIGN_GOOGLE_TEST_CAB=on cargo test test_server_side_credential_access_boundary_live_interoperability
-
-# Run the live client-side CAB and Cloud Storage interoperability test
+# Run the live CAB STS and Cloud Storage interoperability test
 REQSIGN_GOOGLE_TEST_CAB=on cargo test --features credential-access-boundary-client-side test_client_side_credential_access_boundary_live_interoperability
+
+# Run the live service-account token provider and server-side CAB interoperability test
+REQSIGN_GOOGLE_TEST_SERVICE_ACCOUNT_TOKEN=on cargo test test_service_account_token_provider_with_server_side_cab_live_interoperability
 ```
 
 ### GitHub Actions
@@ -125,8 +128,10 @@ The DefaultCredentialProvider automatically detects and handles all these types.
 - All tests are designed to be idempotent and safe to run repeatedly
 - Some credential provider tests use test data that will fail token exchange - this is expected
 - CAB unit tests use Google's non-secret Java auth-library keyset fixture. The live
-  CAB tests are opt-in because they require service-account JSON, a matching Cloud Storage bucket,
-  and a non-empty object prefix; they are not enabled by the repository CI secrets.
+  CAB test is opt-in because it requires a current OAuth access token with the Cloud Platform scope
+  and a matching Cloud Storage bucket and prefix; it is not enabled by the repository CI secrets.
+- The live service-account token provider test is separately opt-in because it requires
+  service-account JSON and a matching Cloud Storage bucket and prefix.
 
 ## Local STS Mock
 

--- a/services/google/tests/README.md
+++ b/services/google/tests/README.md
@@ -42,9 +42,7 @@ Tests for request signing functionality:
 - `REQSIGN_GOOGLE_CREDENTIAL`: Base64-encoded service account JSON (for StaticCredentialProvider)
 - `REQSIGN_GOOGLE_CLOUD_STORAGE_SCOPE`: OAuth2 scope for GCS (e.g., `https://www.googleapis.com/auth/devstorage.read_write`)
 - `REQSIGN_GOOGLE_CLOUD_STORAGE_URL`: GCS bucket URL (e.g., `https://storage.googleapis.com/storage/v1/b/your-bucket`)
-- `REQSIGN_GOOGLE_CAB_SOURCE_TOKEN`: Service-account OAuth access token with the Cloud Platform scope
-- `REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT`: Absolute RFC 3339 expiration of the source token
-- `REQSIGN_GOOGLE_CAB_BUCKET`: Bucket used by the client-issued CAB live test
+- `REQSIGN_GOOGLE_CAB_BUCKET`: Bucket used by the CAB live tests
 - `REQSIGN_GOOGLE_CAB_OBJECT_PREFIX`: Non-empty object prefix used by the CAB list test
 - `GOOGLE_IMPERSONATED_CREDENTIALS`: Path to impersonated service account credential file
 - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`: Workload Identity Provider ID (for GitHub Actions)
@@ -73,7 +71,10 @@ REQSIGN_GOOGLE_TEST_DEFAULT=on cargo test test_default_credential_provider
 # Run all credential provider tests
 cargo test credential_providers::
 
-# Run the live CAB STS and Cloud Storage interoperability test
+# Run the live server-side CAB and Cloud Storage interoperability test
+REQSIGN_GOOGLE_TEST_CAB=on cargo test test_server_side_credential_access_boundary_live_interoperability
+
+# Run the live client-side CAB and Cloud Storage interoperability test
 REQSIGN_GOOGLE_TEST_CAB=on cargo test --features credential-access-boundary-client-side test_client_side_credential_access_boundary_live_interoperability
 ```
 
@@ -124,8 +125,8 @@ The DefaultCredentialProvider automatically detects and handles all these types.
 - All tests are designed to be idempotent and safe to run repeatedly
 - Some credential provider tests use test data that will fail token exchange - this is expected
 - CAB unit tests use Google's non-secret Java auth-library keyset fixture. The live
-  CAB test is opt-in because it requires a current OAuth access token with the Cloud Platform scope
-  and a matching Cloud Storage bucket and prefix; it is not enabled by the repository CI secrets.
+  CAB tests are opt-in because they require service-account JSON, a matching Cloud Storage bucket,
+  and a non-empty object prefix; they are not enabled by the repository CI secrets.
 
 ## Local STS Mock
 

--- a/services/google/tests/credential_access_boundary.rs
+++ b/services/google/tests/credential_access_boundary.rs
@@ -15,58 +15,101 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "credential-access-boundary-client-side")]
-
 use std::env;
 
 use log::warn;
-use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Granter, Result, Signer};
+#[cfg(feature = "credential-access-boundary-client-side")]
+use reqsign_google::ClientSideCredentialAccessBoundaryGranter;
 use reqsign_google::{
-    ClientSideCredentialAccessBoundaryGranter, CredentialAccessBoundaryGrant,
-    CredentialAccessBoundaryPermissions, RequestSigner, TokenCredentialProvider,
+    Credential, CredentialAccessBoundaryGrant, CredentialAccessBoundaryPermissions, RequestSigner,
+    ServerSideCredentialAccessBoundaryGranter, ServiceAccountTokenCredentialProvider,
+    StaticCredentialProvider, TokenCredentialProvider,
 };
 use reqsign_http_send_reqwest::ReqwestHttpSend;
 
+struct LiveConfig {
+    service_account_base64: String,
+    bucket: String,
+    object_prefix: String,
+}
+
+fn live_config() -> Option<LiveConfig> {
+    if env::var("REQSIGN_GOOGLE_TEST_CAB").unwrap_or_default() != "on" {
+        warn!("REQSIGN_GOOGLE_TEST_CAB is not set, skipped");
+        return None;
+    }
+
+    Some(LiveConfig {
+        service_account_base64: env::var("REQSIGN_GOOGLE_CREDENTIAL")
+            .expect("REQSIGN_GOOGLE_CREDENTIAL must contain base64 service-account JSON"),
+        bucket: env::var("REQSIGN_GOOGLE_CAB_BUCKET")
+            .expect("REQSIGN_GOOGLE_CAB_BUCKET must be set"),
+        object_prefix: env::var("REQSIGN_GOOGLE_CAB_OBJECT_PREFIX")
+            .expect("REQSIGN_GOOGLE_CAB_OBJECT_PREFIX must be set"),
+    })
+}
+
+fn source_provider(config: &LiveConfig) -> Result<ServiceAccountTokenCredentialProvider> {
+    Ok(ServiceAccountTokenCredentialProvider::from_provider(
+        StaticCredentialProvider::from_base64(&config.service_account_base64)?,
+    ))
+}
+
+fn prefix_grant(config: &LiveConfig) -> CredentialAccessBoundaryGrant {
+    CredentialAccessBoundaryGrant::for_object_prefix(
+        &config.bucket,
+        &config.object_prefix,
+        CredentialAccessBoundaryPermissions::OBJECT_VIEWER,
+    )
+}
+
+#[tokio::test]
+async fn test_server_side_credential_access_boundary_live_interoperability() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = dotenvy::dotenv();
+    let Some(config) = live_config() else {
+        return Ok(());
+    };
+
+    let context = Context::new().with_http_send(ReqwestHttpSend::default());
+    let downscoped = Granter::new(
+        context,
+        source_provider(&config)?,
+        ServerSideCredentialAccessBoundaryGranter::new(prefix_grant(&config)),
+    )
+    .grant(None)
+    .await?;
+
+    assert_restricted_prefix(downscoped, &config).await
+}
+
+#[cfg(feature = "credential-access-boundary-client-side")]
 #[tokio::test]
 async fn test_client_side_credential_access_boundary_live_interoperability() -> Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
     let _ = dotenvy::dotenv();
-    if env::var("REQSIGN_GOOGLE_TEST_CAB").unwrap_or_default() != "on" {
-        warn!("REQSIGN_GOOGLE_TEST_CAB is not set, skipped");
+    let Some(config) = live_config() else {
         return Ok(());
-    }
-
-    let source_token = env::var("REQSIGN_GOOGLE_CAB_SOURCE_TOKEN")
-        .expect("REQSIGN_GOOGLE_CAB_SOURCE_TOKEN must be set");
-    let source_expires_at = env::var("REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT")
-        .expect("REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT must be set")
-        .parse::<Timestamp>()
-        .expect("REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT must be RFC 3339");
-    let bucket =
-        env::var("REQSIGN_GOOGLE_CAB_BUCKET").expect("REQSIGN_GOOGLE_CAB_BUCKET must be set");
-    let object_prefix = env::var("REQSIGN_GOOGLE_CAB_OBJECT_PREFIX")
-        .expect("REQSIGN_GOOGLE_CAB_OBJECT_PREFIX must be set");
+    };
 
     let context = Context::new().with_http_send(ReqwestHttpSend::default());
-    let grant = CredentialAccessBoundaryGrant::for_object_prefix(
-        &bucket,
-        &object_prefix,
-        CredentialAccessBoundaryPermissions::OBJECT_VIEWER,
-    );
     let downscoped = Granter::new(
         context,
-        TokenCredentialProvider::new(source_token).with_expires_at(source_expires_at),
-        ClientSideCredentialAccessBoundaryGranter::new(grant),
+        source_provider(&config)?,
+        ClientSideCredentialAccessBoundaryGranter::new(prefix_grant(&config)),
     )
     .grant(None)
     .await?;
-    let token = downscoped
-        .token
-        .expect("client-side CAB output must contain a token");
+
+    assert_restricted_prefix(downscoped, &config).await
+}
+
+async fn assert_restricted_prefix(downscoped: Credential, config: &LiveConfig) -> Result<()> {
+    let token = downscoped.token.expect("CAB output must contain a token");
     let expires_at = token
         .expires_at
-        .expect("client-side CAB output must have an expiration");
+        .expect("CAB output must have an expiration");
     let signer = Signer::new(
         Context::new(),
         TokenCredentialProvider::new(token.access_token).with_expires_at(expires_at),
@@ -74,12 +117,13 @@ async fn test_client_side_credential_access_boundary_live_interoperability() -> 
     );
 
     let mut url = reqwest::Url::parse(&format!(
-        "https://storage.googleapis.com/storage/v1/b/{bucket}/o"
+        "https://storage.googleapis.com/storage/v1/b/{}/o",
+        config.bucket
     ))
     .expect("Cloud Storage URL must be valid");
     url.query_pairs_mut()
         .append_pair("maxResults", "1")
-        .append_pair("prefix", &object_prefix);
+        .append_pair("prefix", &config.object_prefix);
     let request = http::Request::get(url.as_str())
         .body("")
         .expect("Cloud Storage request must build");
@@ -90,29 +134,28 @@ async fn test_client_side_credential_access_boundary_live_interoperability() -> 
             http::Request::from_parts(parts, body)
                 .try_into()
                 .map_err(|err| {
-                    reqsign_core::Error::unexpected(
-                        "failed to convert client-side CAB live request",
-                    )
-                    .with_source(err)
+                    reqsign_core::Error::unexpected("failed to convert CAB live request")
+                        .with_source(err)
                 })?,
         )
         .await
         .map_err(|err| {
-            reqsign_core::Error::unexpected("client-side CAB live request failed").with_source(err)
+            reqsign_core::Error::unexpected("CAB live request failed").with_source(err)
         })?;
     assert!(
         response.status().is_success(),
-        "client-issued CAB token was rejected with status {}",
+        "CAB token was rejected with status {}",
         response.status()
     );
 
-    let disallowed_prefix = if object_prefix.starts_with('a') {
+    let disallowed_prefix = if config.object_prefix.starts_with('a') {
         "b-reqsign-cab-out-of-scope/"
     } else {
         "a-reqsign-cab-out-of-scope/"
     };
     let mut url = reqwest::Url::parse(&format!(
-        "https://storage.googleapis.com/storage/v1/b/{bucket}/o"
+        "https://storage.googleapis.com/storage/v1/b/{}/o",
+        config.bucket
     ))
     .expect("Cloud Storage URL must be valid");
     url.query_pairs_mut()
@@ -128,21 +171,18 @@ async fn test_client_side_credential_access_boundary_live_interoperability() -> 
             http::Request::from_parts(parts, body)
                 .try_into()
                 .map_err(|err| {
-                    reqsign_core::Error::unexpected(
-                        "failed to convert out-of-scope client-side CAB live request",
-                    )
-                    .with_source(err)
+                    reqsign_core::Error::unexpected("failed to convert out-of-scope CAB request")
+                        .with_source(err)
                 })?,
         )
         .await
         .map_err(|err| {
-            reqsign_core::Error::unexpected("out-of-scope client-side CAB live request failed")
-                .with_source(err)
+            reqsign_core::Error::unexpected("out-of-scope CAB live request failed").with_source(err)
         })?;
     assert_eq!(
         response.status(),
         reqwest::StatusCode::FORBIDDEN,
-        "client-issued CAB token unexpectedly accessed an out-of-scope prefix"
+        "CAB token unexpectedly accessed an out-of-scope prefix"
     );
     Ok(())
 }

--- a/services/google/tests/service_account_token.rs
+++ b/services/google/tests/service_account_token.rs
@@ -15,58 +15,55 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg(feature = "credential-access-boundary-client-side")]
-
 use std::env;
 
 use log::warn;
-use reqsign_core::time::Timestamp;
 use reqsign_core::{Context, Granter, Result, Signer};
 use reqsign_google::{
-    ClientSideCredentialAccessBoundaryGranter, CredentialAccessBoundaryGrant,
-    CredentialAccessBoundaryPermissions, RequestSigner, TokenCredentialProvider,
+    CredentialAccessBoundaryGrant, CredentialAccessBoundaryPermissions, RequestSigner,
+    ServerSideCredentialAccessBoundaryGranter, ServiceAccountTokenCredentialProvider,
+    StaticCredentialProvider, TokenCredentialProvider,
 };
 use reqsign_http_send_reqwest::ReqwestHttpSend;
 
 #[tokio::test]
-async fn test_client_side_credential_access_boundary_live_interoperability() -> Result<()> {
+async fn test_service_account_token_provider_with_server_side_cab_live_interoperability()
+-> Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
     let _ = dotenvy::dotenv();
-    if env::var("REQSIGN_GOOGLE_TEST_CAB").unwrap_or_default() != "on" {
-        warn!("REQSIGN_GOOGLE_TEST_CAB is not set, skipped");
+    if env::var("REQSIGN_GOOGLE_TEST_SERVICE_ACCOUNT_TOKEN").unwrap_or_default() != "on" {
+        warn!("REQSIGN_GOOGLE_TEST_SERVICE_ACCOUNT_TOKEN is not set, skipped");
         return Ok(());
     }
 
-    let source_token = env::var("REQSIGN_GOOGLE_CAB_SOURCE_TOKEN")
-        .expect("REQSIGN_GOOGLE_CAB_SOURCE_TOKEN must be set");
-    let source_expires_at = env::var("REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT")
-        .expect("REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT must be set")
-        .parse::<Timestamp>()
-        .expect("REQSIGN_GOOGLE_CAB_SOURCE_EXPIRES_AT must be RFC 3339");
+    let service_account_base64 = env::var("REQSIGN_GOOGLE_CREDENTIAL")
+        .expect("REQSIGN_GOOGLE_CREDENTIAL must contain base64 service-account JSON");
     let bucket =
         env::var("REQSIGN_GOOGLE_CAB_BUCKET").expect("REQSIGN_GOOGLE_CAB_BUCKET must be set");
     let object_prefix = env::var("REQSIGN_GOOGLE_CAB_OBJECT_PREFIX")
         .expect("REQSIGN_GOOGLE_CAB_OBJECT_PREFIX must be set");
 
-    let context = Context::new().with_http_send(ReqwestHttpSend::default());
+    let source = ServiceAccountTokenCredentialProvider::from_provider(
+        StaticCredentialProvider::from_base64(&service_account_base64)?,
+    );
     let grant = CredentialAccessBoundaryGrant::for_object_prefix(
         &bucket,
         &object_prefix,
         CredentialAccessBoundaryPermissions::OBJECT_VIEWER,
     );
     let downscoped = Granter::new(
-        context,
-        TokenCredentialProvider::new(source_token).with_expires_at(source_expires_at),
-        ClientSideCredentialAccessBoundaryGranter::new(grant),
+        Context::new().with_http_send(ReqwestHttpSend::default()),
+        source,
+        ServerSideCredentialAccessBoundaryGranter::new(grant),
     )
     .grant(None)
     .await?;
     let token = downscoped
         .token
-        .expect("client-side CAB output must contain a token");
+        .expect("server-side CAB output must contain a token");
     let expires_at = token
         .expires_at
-        .expect("client-side CAB output must have an expiration");
+        .expect("server-side CAB output must have an expiration");
     let signer = Signer::new(
         Context::new(),
         TokenCredentialProvider::new(token.access_token).with_expires_at(expires_at),
@@ -91,18 +88,19 @@ async fn test_client_side_credential_access_boundary_live_interoperability() -> 
                 .try_into()
                 .map_err(|err| {
                     reqsign_core::Error::unexpected(
-                        "failed to convert client-side CAB live request",
+                        "failed to convert service-account token live request",
                     )
                     .with_source(err)
                 })?,
         )
         .await
         .map_err(|err| {
-            reqsign_core::Error::unexpected("client-side CAB live request failed").with_source(err)
+            reqsign_core::Error::unexpected("service-account token live request failed")
+                .with_source(err)
         })?;
     assert!(
         response.status().is_success(),
-        "client-issued CAB token was rejected with status {}",
+        "server-issued CAB token was rejected with status {}",
         response.status()
     );
 
@@ -129,20 +127,22 @@ async fn test_client_side_credential_access_boundary_live_interoperability() -> 
                 .try_into()
                 .map_err(|err| {
                     reqsign_core::Error::unexpected(
-                        "failed to convert out-of-scope client-side CAB live request",
+                        "failed to convert out-of-scope service-account token live request",
                     )
                     .with_source(err)
                 })?,
         )
         .await
         .map_err(|err| {
-            reqsign_core::Error::unexpected("out-of-scope client-side CAB live request failed")
-                .with_source(err)
+            reqsign_core::Error::unexpected(
+                "out-of-scope service-account token live request failed",
+            )
+            .with_source(err)
         })?;
     assert_eq!(
         response.status(),
         reqwest::StatusCode::FORBIDDEN,
-        "client-issued CAB token unexpectedly accessed an out-of-scope prefix"
+        "server-issued CAB token unexpectedly accessed an out-of-scope prefix"
     );
     Ok(())
 }


### PR DESCRIPTION
Closes #859.

Service-account credential files currently produce a credential that only `RequestSigner` can exchange for an OAuth token internally, so they cannot be composed with token-only consumers such as the server-side Credential Access Boundary granter.

This adds `ServiceAccountTokenCredentialProvider`, accepting either a bound `ServiceAccount` or an explicit Google credential provider. It performs the JWT bearer exchange through the configured context and returns a token-only `Credential` with the source service-account email preserved as signer identity. Static, file, and default credential sources can therefore feed both existing CAB granters without host-side OAuth protocol code.

The OAuth implementation is shared with `RequestSigner`. Scope resolution remains explicit override, then `GOOGLE_SCOPE`, then the Cloud Platform default. The required `expires_in` response is converted to a conservative absolute expiration anchored immediately before network I/O and revalidated after the response; private keys, assertions, access tokens, and response bodies are excluded from `Debug` and returned errors. The provider does not add another cache or change the default credential chain.

The opt-in CAB live test now covers both server-side and client-side flows from service-account JSON. It was not exercised locally because the live Google credentials and bucket configuration were not available.
