### PR TITLE
ci: migrate to Hawkeye v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install Hawkeye
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
+        with:
+          tool: hawkeye@7.0.0
       - name: Check license headers
-        uses: korandoru/hawkeye@7ffde2c5fd29f3c486e4a6510436dca54f386e2a # v6.5.0
+        run: hawkeye check
 
   build:
     runs-on: ${{ matrix.os }}

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-headerPath = "Apache-2.0-ASF.txt"
+[header]
+builtin = "Apache-2.0-ASF"
 
-includes = ['**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']
+[files]
+includes = ["**/*.rs", "**/*.yml", "**/*.yaml", "**/*.toml"]


### PR DESCRIPTION
## Summary

- migrate `licenserc.toml` to Hawkeye v7's sectioned snake_case schema
- replace the removed Hawkeye-specific GitHub Action with an explicitly installed v7 CLI
- run `hawkeye check` explicitly in CI

This supersedes the incomplete dependency-only update in #857, whose license job invokes Hawkeye without a subcommand.

## Validation

- `hawkeye 7.0.0 check` — 248 files, 0 changes, 0 conflicts, 0 unsupported
- `hawkeye 7.0.1 check` — 248 files, 0 changes, 0 conflicts, 0 unsupported
- `git diff --check`
