### PR TITLE
refactor: replace mea with asyncband 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ reqsign-volcengine-tos = { version = "3.1.2", path = "services/volcengine-tos" }
 # Crates.io dependencies
 aes-gcm = "0.11"
 anyhow = "1"
-asyncband = { version = "0.7", features = ["mutex"] }
+asyncband = { version = "0.7.1", features = ["mutex"] }
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 bytes = "1"
 criterion = { version = "0.8.1", features = ["async_tokio", "html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal-reqsign"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [workspace.dependencies]
 # Workspace dependencies
@@ -45,6 +45,7 @@ reqsign-volcengine-tos = { version = "3.1.2", path = "services/volcengine-tos" }
 # Crates.io dependencies
 aes-gcm = "0.11"
 anyhow = "1"
+asyncband = { version = "0.7", features = ["mutex"] }
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 bytes = "1"
 criterion = { version = "0.8.1", features = ["async_tokio", "html_reports"] }
@@ -57,7 +58,6 @@ hmac = "0.13"
 http = "1"
 jiff = "0.2"
 log = "0.4"
-mea = "0.6.4"
 pem = "4.0"
 percent-encoding = "2"
 p256 = { version = "0.14.0", default-features = false, features = ["ecdsa"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ jwt = ["dep:rsa", "dep:serde", "dep:serde_json"]
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
@@ -41,7 +42,6 @@ hmac = { workspace = true }
 http = { workspace = true }
 jiff = { workspace = true }
 log = { workspace = true }
-mea = { workspace = true }
 percent-encoding = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }

--- a/core/src/signer.rs
+++ b/core/src/signer.rs
@@ -23,7 +23,7 @@ use crate::Result;
 use crate::SignRequest;
 use crate::SignRequestDyn;
 use crate::SigningCredential;
-use mea::mutex::Mutex;
+use asyncband::mutex::Mutex;
 use std::any::type_name;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

- replace `mea::mutex::Mutex` with `asyncband::mutex::Mutex` from AsyncBand 0.7.1
- enable only AsyncBand's `mutex` feature
- raise the workspace MSRV to Rust 1.86, matching AsyncBand 0.7.1
- require 0.7.1 because AsyncBand 0.7.0 has been yanked

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`
- `cargo test --doc --all-features --workspace`
